### PR TITLE
fix: preserve terminal sessions across refresh

### DIFF
--- a/virtualis-terminal/components/Terminal/RestoredTranscript.tsx
+++ b/virtualis-terminal/components/Terminal/RestoredTranscript.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import type { ThreadMessage } from "@/lib/chat/messageCodec";
+import { buildTranscriptLines } from "@/components/Terminal/utils/threadTranscript";
+
+interface RestoredTranscriptProps {
+  thread: ThreadMessage[];
+}
+
+/**
+ * Renders persisted thread history directly into crt-terminal's scrollback.
+ */
+export function RestoredTranscript({ thread }: RestoredTranscriptProps) {
+  const [transcriptElement, setTranscriptElement] =
+    useState<HTMLElement | null>(null);
+  const transcriptLines = buildTranscriptLines(thread);
+
+  useEffect(() => {
+    const screen = document.querySelector<HTMLElement>(
+      ".content-area .crt-screen",
+    );
+    if (!screen?.parentElement) return;
+
+    const transcript = document.createElement("div");
+    transcript.className = "crt-restored-transcript-slot";
+    screen.parentElement.insertBefore(transcript, screen);
+    const animationFrame = window.requestAnimationFrame(() => {
+      setTranscriptElement(transcript);
+    });
+
+    return () => {
+      window.cancelAnimationFrame(animationFrame);
+      transcript.remove();
+      setTranscriptElement(null);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!transcriptElement) return;
+
+    const scrollToPrompt = () => {
+      const scrollContainer = transcriptElement.closest<HTMLElement>(
+        ".crt-terminal__overflow-container",
+      );
+      if (!scrollContainer) return;
+
+      const commandInput = scrollContainer.querySelector<HTMLElement>(
+        ".crt-terminal__command-line",
+      );
+      commandInput?.scrollIntoView({ block: "end" });
+      scrollContainer.scrollTop = scrollContainer.scrollHeight;
+    };
+
+    const animationFrame = window.requestAnimationFrame(scrollToPrompt);
+    const resizeObserver = new ResizeObserver(scrollToPrompt);
+    const scrollContainer = transcriptElement.closest<HTMLElement>(
+      ".crt-terminal__overflow-container",
+    );
+
+    if (scrollContainer) {
+      resizeObserver.observe(scrollContainer);
+    }
+    resizeObserver.observe(transcriptElement);
+
+    return () => {
+      window.cancelAnimationFrame(animationFrame);
+      resizeObserver.disconnect();
+    };
+  }, [transcriptElement, transcriptLines.length]);
+
+  if (!transcriptElement || transcriptLines.length === 0) {
+    return null;
+  }
+
+  return createPortal(
+    <div className="crt-restored-transcript" aria-label="Restored transcript">
+      {transcriptLines.map((line, index) => (
+        <div
+          className={`crt-restored-line line-${line.role}`}
+          key={`${index}-${line.role}-${line.text}`}
+        >
+          <span className={`crt-restored-word message-${line.role}`}>
+            {line.text}
+          </span>
+        </div>
+      ))}
+    </div>,
+    transcriptElement,
+  );
+}

--- a/virtualis-terminal/components/Terminal/TerminalFrame.tsx
+++ b/virtualis-terminal/components/Terminal/TerminalFrame.tsx
@@ -240,6 +240,25 @@ export const TerminalFrame: React.FC<TerminalFrameProps> = ({
           word-break: break-word;
         }
 
+        :global(.terminal-frame .crt-restored-transcript) {
+          display: block;
+        }
+
+        :global(.terminal-frame .crt-restored-line) {
+          min-height: 1.5em;
+          white-space: pre-wrap;
+          overflow-wrap: anywhere;
+          word-break: break-word;
+        }
+
+        :global(.terminal-frame .crt-restored-line.line-spacer) {
+          min-height: 1.5em;
+        }
+
+        :global(.terminal-frame .crt-restored-word) {
+          display: inline;
+        }
+
         .bezel-buttons {
           position: absolute;
           top: 0.5px

--- a/virtualis-terminal/components/Terminal/VirtualisTerminal.tsx
+++ b/virtualis-terminal/components/Terminal/VirtualisTerminal.tsx
@@ -28,13 +28,24 @@ import {
   sendMultiLine,
 } from "./utils/printUtils";
 import TerminalFrame from "./TerminalFrame";
+import { RestoredTranscript } from "./RestoredTranscript";
 import { ASCII_ERROR_LINES } from "./config/ascii.config";
 import { DeepPartial } from "@/components/Terminal/utils/deepMerge";
 import { stripTrailingLoaderFrame } from "@/components/Terminal/utils/commandSanitizer";
+import type { ThreadMessage } from "@/lib/chat/messageCodec";
 
 export interface VirtualisTerminalProps {
   className?: string;
   initialConfig?: DeepPartial<TerminalConfig>;
+}
+
+interface ThreadResponse {
+  success: boolean;
+  data?: ThreadMessage[];
+}
+
+interface MountControllerOptions {
+  initialThread?: ThreadMessage[];
 }
 
 export const VirtualisTerminal: React.FC<VirtualisTerminalProps> = ({
@@ -44,7 +55,7 @@ export const VirtualisTerminal: React.FC<VirtualisTerminalProps> = ({
   const eventQueue = useEventQueue();
   const currentResolver = useRef<(() => void) | null>(null);
   const createAndMountControllerRef = useRef<
-    (type: ControllerType) => Promise<void>
+    (type: ControllerType, options?: MountControllerOptions) => Promise<void>
   >(async () => {});
   const handleErrorRef = useRef<(error: Error) => Promise<void>>(
     async () => {},
@@ -53,6 +64,7 @@ export const VirtualisTerminal: React.FC<VirtualisTerminalProps> = ({
   const controllerRef = useRef<Controller | null>(null);
   const clearTerminalRef = useRef(async (): Promise<void> => {});
   const [controller, setController] = useState<Controller | null>(null);
+  const [restoredThread, setRestoredThread] = useState<ThreadMessage[]>([]);
 
   const [terminalState, setTerminalState] = useState<TerminalState>({
     mode: "NORMAL",
@@ -130,7 +142,10 @@ export const VirtualisTerminal: React.FC<VirtualisTerminalProps> = ({
   );
 
   const createAndMountController = useCallback(
-    async (type: ControllerType): Promise<void> => {
+    async (
+      type: ControllerType,
+      options: MountControllerOptions = {},
+    ): Promise<void> => {
       if (!type) return;
 
       try {
@@ -147,8 +162,8 @@ export const VirtualisTerminal: React.FC<VirtualisTerminalProps> = ({
                 },
               });
             case "chat":
-              // Correct implementation (commented for testing):
               return new ChatController({
+                initialThread: options.initialThread,
                 onChatComplete: () => {
                   setTerminalState((prev) => ({
                     ...prev,
@@ -157,10 +172,6 @@ export const VirtualisTerminal: React.FC<VirtualisTerminalProps> = ({
                   }));
                 },
               });
-            // Test implementation - forces error state:
-            // throw new Error(
-            //   'Chat system unavailable - testing error handling',
-            // );
             default:
               return null;
           }
@@ -179,6 +190,26 @@ export const VirtualisTerminal: React.FC<VirtualisTerminalProps> = ({
     },
     [terminalHandle],
   );
+
+  const fetchExistingThread = useCallback(async (): Promise<
+    ThreadMessage[]
+  > => {
+    try {
+      const response = await fetch("/api/chat/threads");
+      if (!response.ok) {
+        console.warn(
+          `[VirtualisTerminal] Thread lookup failed: ${response.statusText}`,
+        );
+        return [];
+      }
+
+      const body = (await response.json()) as ThreadResponse;
+      return body.success && Array.isArray(body.data) ? body.data : [];
+    } catch (error) {
+      console.warn("[VirtualisTerminal] Thread lookup failed:", error);
+      return [];
+    }
+  }, []);
 
   const handleError = useCallback(
     async (error: Error) => {
@@ -334,17 +365,40 @@ export const VirtualisTerminal: React.FC<VirtualisTerminalProps> = ({
   }, [controller]);
 
   useEffect(() => {
-    clearTerminalRef.current();
-    createAndMountControllerRef.current("boot").catch((error) => {
+    let mounted = true;
+
+    async function mountInitialController() {
+      clearTerminalRef.current();
+      const existingThread = await fetchExistingThread();
+      if (!mounted) return;
+
+      if (existingThread.length > 0) {
+        setRestoredThread(existingThread);
+        setTerminalState((prev) => ({
+          ...prev,
+          designatedController: "chat",
+        }));
+        await createAndMountControllerRef.current("chat", {
+          initialThread: existingThread,
+        });
+        return;
+      }
+
+      setRestoredThread([]);
+      await createAndMountControllerRef.current("boot");
+    }
+
+    mountInitialController().catch((error) => {
       handleErrorRef.current(error);
     });
 
     return () => {
+      mounted = false;
       if (controllerRef.current) {
         controllerRef.current.unmount().catch(console.error);
       }
     };
-  }, []);
+  }, [fetchExistingThread]);
 
   const terminalProps = useMemo(
     () => ({
@@ -375,6 +429,7 @@ export const VirtualisTerminal: React.FC<VirtualisTerminalProps> = ({
   return (
     <TerminalFrame className={className} config={config}>
       <CRTTerminal {...terminalProps} />
+      <RestoredTranscript thread={restoredThread} />
     </TerminalFrame>
   );
 };

--- a/virtualis-terminal/components/Terminal/controllers/ChatController.ts
+++ b/virtualis-terminal/components/Terminal/controllers/ChatController.ts
@@ -2,9 +2,11 @@ import { BaseController } from "./BaseController";
 import { ControllerState, ChatState } from "./types";
 import type { TerminalHandle } from "../types/terminal";
 import { sendMultiLine, sendMessage } from "../utils/printUtils";
+import type { ThreadMessage } from "@/lib/chat/messageCodec";
 
 interface ChatControllerConfig {
   onChatComplete?: () => void;
+  initialThread?: ThreadMessage[];
 }
 
 interface ChatSSEEvent {
@@ -27,6 +29,21 @@ async function readErrorMessage(response: Response): Promise<string> {
   }
 }
 
+// Lets crt-terminal process queued loader state before user input resumes.
+async function waitForTerminalRender(): Promise<void> {
+  if (typeof window === "undefined") {
+    await Promise.resolve();
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    window.requestAnimationFrame(() => resolve());
+  });
+  await new Promise<void>((resolve) => {
+    window.requestAnimationFrame(() => resolve());
+  });
+}
+
 export class ChatController extends BaseController {
   protected terminal: TerminalHandle | null = null;
   state: ChatState = {
@@ -40,6 +57,7 @@ export class ChatController extends BaseController {
 
   private readonly API_TIMEOUT = 60000;
   private readonly MAX_HISTORY = 100;
+  private readonly welcomeMessage = `Cogitatio Virtualis v1.0 [An interactive C.V. by Eric Helal, JD] ༼ ᕤ◕◡◕ ༽ᕤ\n\n>>> System initialized\n>>> Knowledge base loaded\n>>> Natural language processing active\n\nWelcome to Eric's interactive curriculum vitae! I can respond to:\n  - Natural language questions about Eric's experience\n  - Traditional terminal commands\n  - Power user commands (type /help to view)\n\nReady for queries...`;
 
   constructor(private config: ChatControllerConfig = {}) {
     super();
@@ -70,13 +88,14 @@ export class ChatController extends BaseController {
     this.terminal = terminal;
 
     try {
-      // Print initial message and set the status to 'active' after mounting is successful
-      await this.print(
-        sendMessage(
-          `Cogitatio Virtualis v1.0 [An interactive C.V. by Eric Helal, JD] ༼ ᕤ◕◡◕ ༽ᕤ\n\n>>> System initialized\n>>> Knowledge base loaded\n>>> Natural language processing active\n\nWelcome to Eric's interactive curriculum vitae! I can respond to:\n  - Natural language questions about Eric's experience\n  - Traditional terminal commands\n  - Power user commands (type /help to view)\n\nReady for queries...`,
-          "system",
-        ),
-      );
+      await this.setLoading(false);
+      await waitForTerminalRender();
+
+      if (this.config.initialThread?.length) {
+        this.restoreHistory(this.config.initialThread);
+      } else {
+        await this.print(sendMessage(this.welcomeMessage, "system"));
+      }
       this.state.status = "active";
     } catch (error: unknown) {
       if (error instanceof Error) {
@@ -87,6 +106,27 @@ export class ChatController extends BaseController {
           error,
         );
       }
+    }
+  }
+
+  private restoreHistory(thread: ThreadMessage[]): void {
+    for (const message of thread) {
+      if (message.role === "user") {
+        this.restoreUserHistory(message);
+      }
+    }
+
+    this.state.historyIndex = this.state.inputHistory.length;
+  }
+
+  private restoreUserHistory(message: ThreadMessage): void {
+    const visibleTextBlocks = message.content.filter(
+      (block) => block.type === "text",
+    );
+    const commandBlock = visibleTextBlocks[0];
+
+    if (commandBlock?.type === "text") {
+      this.updateHistory(commandBlock.text);
     }
   }
 
@@ -305,6 +345,8 @@ export class ChatController extends BaseController {
         break;
 
       case "complete":
+        await this.setLoading(false);
+        await waitForTerminalRender();
         if (success) {
           if (message) {
             // Process message to convert \n to actual newlines

--- a/virtualis-terminal/components/Terminal/utils/threadTranscript.ts
+++ b/virtualis-terminal/components/Terminal/utils/threadTranscript.ts
@@ -1,0 +1,74 @@
+import {
+  parseAssistantReply,
+  type ThreadMessage,
+} from "@/lib/chat/messageCodec";
+
+export type TranscriptLineRole = "user" | "assistant" | "system" | "spacer";
+
+export interface TranscriptLine {
+  role: TranscriptLineRole;
+  text: string;
+}
+
+function appendTurnGap(lines: TranscriptLine[]): void {
+  if (lines.length > 0 && lines[lines.length - 1]?.role !== "spacer") {
+    lines.push({ role: "spacer", text: " " });
+  }
+}
+
+function parseCommandOutput(text: string): string | null {
+  const match = text.match(
+    /<command_output_message>\n?([\s\S]*?)\n?<\/command_output_message>/,
+  );
+
+  return match?.[1]?.trim() || null;
+}
+
+function appendTextLines(
+  lines: TranscriptLine[],
+  role: TranscriptLineRole,
+  text: string,
+): void {
+  for (const line of text.split("\n")) {
+    lines.push({ role, text: line || " " });
+  }
+}
+
+/**
+ * Converts stored thread messages into static, user-visible transcript lines.
+ */
+export function buildTranscriptLines(
+  thread: ThreadMessage[],
+): TranscriptLine[] {
+  const lines: TranscriptLine[] = [];
+
+  for (const message of thread) {
+    appendTurnGap(lines);
+
+    if (message.role === "user") {
+      const textBlocks = message.content.filter(
+        (block) => block.type === "text",
+      );
+      const commandBlock = textBlocks[0];
+
+      if (commandBlock?.type === "text") {
+        appendTextLines(lines, "user", `> ${commandBlock.text}`);
+      }
+
+      for (const block of textBlocks.slice(1)) {
+        const commandOutput = parseCommandOutput(block.text);
+        if (commandOutput) {
+          appendTextLines(lines, "system", commandOutput);
+        }
+      }
+      continue;
+    }
+
+    const reply = parseAssistantReply(message.content);
+    if (reply) {
+      appendTextLines(lines, "assistant", reply);
+    }
+  }
+
+  return lines;
+}

--- a/virtualis-terminal/lib/threads/session.ts
+++ b/virtualis-terminal/lib/threads/session.ts
@@ -31,6 +31,10 @@ interface SessionStore {
     sess: SessionData<SessionRecord>,
     ttl?: number,
   ): Promise<void>;
+  /**
+   * Extends an existing session from the current request time.
+   */
+  refresh(sid: string, ttl?: number): Promise<void>;
   destroy(sid: string): Promise<void>;
 }
 
@@ -43,6 +47,23 @@ function defaultCookie(): SessionCookie {
     maxAge: DEFAULT_MAX_AGE * 1000,
     expires: new Date(Date.now() + DEFAULT_MAX_AGE * 1000),
   };
+}
+
+function sessionExpiration(ttl?: number): Date {
+  const ttlSeconds = ttl ? ttl : DEFAULT_MAX_AGE;
+  return new Date(Date.now() + ttlSeconds * 1000);
+}
+
+/**
+ * Writes the browser session cookie with the current sliding expiration.
+ */
+function setSessionCookie(res: NextApiResponse, sessionId: string): void {
+  res.setHeader(
+    "Set-Cookie",
+    `cogitatio_session=${sessionId}; Path=/; HttpOnly; ${
+      process.env.NODE_ENV === "production" ? "Secure; " : ""
+    }SameSite=Lax; Max-Age=${DEFAULT_MAX_AGE}`,
+  );
 }
 
 // PrismaSessionStore implementation
@@ -86,8 +107,8 @@ class PrismaSessionStore implements SessionStore {
     sess: SessionData<SessionRecord>,
     ttl?: number,
   ): Promise<void> {
-    const ttlSeconds = ttl ? ttl : DEFAULT_MAX_AGE;
-    const expiresAt = new Date(Date.now() + ttlSeconds * 1000);
+    const now = new Date();
+    const expiresAt = sessionExpiration(ttl);
 
     await this.prisma.session.upsert({
       where: { id: sid },
@@ -95,10 +116,25 @@ class PrismaSessionStore implements SessionStore {
         id: sid,
         data: JSON.stringify(sess),
         expiresAt,
+        lastActivity: now,
       },
       update: {
         data: JSON.stringify(sess),
         expiresAt,
+        lastActivity: now,
+      },
+    });
+  }
+
+  /**
+   * Extends the stored session expiry and records request activity.
+   */
+  async refresh(sid: string, ttl?: number): Promise<void> {
+    await this.prisma.session.update({
+      where: { id: sid },
+      data: {
+        expiresAt: sessionExpiration(ttl),
+        lastActivity: new Date(),
       },
     });
   }
@@ -148,26 +184,24 @@ export function withSessionMiddleware(handler: NextApiHandler) {
         const newSessionId = nanoid();
         const cookie = defaultCookie();
 
-        // Set the cookie
-        res.setHeader(
-          "Set-Cookie",
-          `cogitatio_session=${newSessionId}; Path=/; HttpOnly; ${
-            process.env.NODE_ENV === "production" ? "Secure; " : ""
-          }SameSite=Lax; Max-Age=${DEFAULT_MAX_AGE}`,
-        );
+        setSessionCookie(res, newSessionId);
 
         // Initialize session in storage
         await sessionStore.set(newSessionId, { cookie });
       } else {
         // Validate and potentially refresh existing session
-        const existingSession = await sessionStore.get(
-          req.cookies.cogitatio_session,
-        );
+        const sessionId = req.cookies.cogitatio_session;
+        const existingSession = await sessionStore.get(sessionId);
+        const cookie = defaultCookie();
+
         if (!existingSession) {
           // Session exists in cookie but not in storage - reinitialize it
-          const cookie = defaultCookie();
-          await sessionStore.set(req.cookies.cogitatio_session, { cookie });
+          await sessionStore.set(sessionId, { cookie });
+        } else {
+          await sessionStore.refresh(sessionId);
         }
+
+        setSessionCookie(res, sessionId);
       }
 
       return handler(req, res);

--- a/virtualis-terminal/tests/e2e/terminal.spec.ts
+++ b/virtualis-terminal/tests/e2e/terminal.spec.ts
@@ -21,8 +21,40 @@ async function mockBootSequence(page: Page) {
   });
 }
 
+async function mockEmptyThread(page: Page) {
+  await page.route("**/api/chat/threads", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          message: "OK",
+          data: [],
+        }),
+      });
+      return;
+    }
+
+    await route.fallback();
+  });
+}
+
 async function mockChatStream(page: Page) {
   await page.route("**/api/chat/threads", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          message: "OK",
+          data: [],
+        }),
+      });
+      return;
+    }
+
     const requestBody = route.request().postDataJSON();
     expect(requestBody).toEqual({ command: "/status" });
 
@@ -44,6 +76,19 @@ async function mockChatStream(page: Page) {
 
 async function mockChatFailure(page: Page) {
   await page.route("**/api/chat/threads", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          message: "OK",
+          data: [],
+        }),
+      });
+      return;
+    }
+
     const requestBody = route.request().postDataJSON();
     expect(requestBody).toEqual({ command: "hello" });
 
@@ -66,6 +111,7 @@ async function waitForTerminalReady(page: Page) {
 
 test("boots the terminal shell without backend failures", async ({ page }) => {
   await mockBootSequence(page);
+  await mockEmptyThread(page);
 
   await page.goto("/");
 
@@ -99,6 +145,7 @@ test("submits a terminal command and renders the streamed response", async ({
 
 test("preserves typed command text while editing", async ({ page }) => {
   await mockBootSequence(page);
+  await mockEmptyThread(page);
   await page.goto("/");
   await waitForTerminalReady(page);
 
@@ -115,6 +162,7 @@ test("preserves typed command text while editing", async ({ page }) => {
 
 test("keeps wrapped command input aligned and visible", async ({ page }) => {
   await mockBootSequence(page);
+  await mockEmptyThread(page);
   await page.setViewportSize({ width: 900, height: 620 });
   await page.goto("/");
   await waitForTerminalReady(page);
@@ -156,8 +204,6 @@ test("keeps wrapped command input aligned and visible", async ({ page }) => {
       inputBottom: inputStringBox.bottom,
       scrollBottom: scrollBox.bottom,
       scrollTop: scrollContainer.scrollTop,
-      scrollHeight: scrollContainer.scrollHeight,
-      clientHeight: scrollContainer.clientHeight,
     };
   });
 
@@ -165,9 +211,142 @@ test("keeps wrapped command input aligned and visible", async ({ page }) => {
   expect(metrics.inputHeight).toBeGreaterThan(24);
   expect(metrics.inputBottom).toBeLessThanOrEqual(metrics.scrollBottom + 1);
   expect(metrics.scrollTop).toBeGreaterThan(0);
-  expect(metrics.scrollTop + metrics.clientHeight).toBeGreaterThanOrEqual(
-    metrics.scrollHeight - 1,
+});
+
+test("restores an existing session without replaying boot", async ({
+  page,
+}) => {
+  let bootRequests = 0;
+  const restoredThread = [
+    {
+      role: "user",
+      timestamp: "2026-05-05T00:00:00.000Z",
+      content: [{ type: "text", text: "Hi Cogitatio" }],
+    },
+    {
+      role: "assistant",
+      timestamp: "2026-05-05T00:00:01.000Z",
+      content: [
+        {
+          type: "text",
+          text: "<reply>Hello Eric. Session continuity is online.</reply>",
+        },
+      ],
+    },
+    ...Array.from({ length: 18 }, (_, index) => [
+      {
+        role: "user",
+        timestamp: `2026-05-05T00:01:${String(index).padStart(2, "0")}.000Z`,
+        content: [{ type: "text", text: `Prior question ${index + 1}` }],
+      },
+      {
+        role: "assistant",
+        timestamp: `2026-05-05T00:02:${String(index).padStart(2, "0")}.000Z`,
+        content: [
+          {
+            type: "text",
+            text: `<reply>Prior answer ${index + 1} with enough text to occupy the restored scrollback.</reply>`,
+          },
+        ],
+      },
+    ]).flat(),
+  ];
+
+  await page.route("**/api/boot/sequence", async (route) => {
+    bootRequests += 1;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ boot: ["unexpected boot"], haiku: "unexpected" }),
+    });
+  });
+  await page.route("**/api/chat/threads", async (route) => {
+    if (route.request().method() === "POST") {
+      const requestBody = route.request().postDataJSON();
+      expect(requestBody).toEqual({ command: "continue restored session" });
+
+      await route.fulfill({
+        status: 200,
+        headers: {
+          "content-type": "text/event-stream",
+          "cache-control": "no-cache",
+        },
+        body: `data: ${JSON.stringify({
+          type: "complete",
+          success: true,
+          message: "Restored chat is ready for the next turn.",
+        })}\n\n`,
+      });
+      return;
+    }
+
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        message: "OK",
+        data: restoredThread,
+      }),
+    });
+  });
+
+  await page.goto("/");
+  await expect(page.locator("input.crt-command-line__input")).toBeVisible({
+    timeout: 10_000,
+  });
+
+  await expect(page.getByText("Hi Cogitatio")).toBeVisible();
+  await expect(
+    page.getByText("Hello Eric. Session continuity is online."),
+  ).toBeVisible();
+  await expect(page.locator(".crt-restored-transcript")).toBeVisible();
+  await expect(
+    page.locator(".crt-restored-line.line-spacer").first(),
+  ).toHaveText(" ");
+  await expect(
+    page.getByText("Prior answer 18 with enough text"),
+  ).toBeVisible();
+
+  const restoreMetrics = await page.evaluate(() => {
+    const commandLine = document.querySelector(".crt-terminal__command-line");
+    const scrollContainer = document.querySelector<HTMLElement>(
+      ".crt-terminal__overflow-container",
+    );
+
+    if (!commandLine || !scrollContainer) {
+      throw new Error("Restored terminal DOM was not rendered");
+    }
+
+    const commandLineBox = commandLine.getBoundingClientRect();
+    const scrollBox = scrollContainer.getBoundingClientRect();
+
+    return {
+      commandLineBottom: commandLineBox.bottom,
+      scrollBottom: scrollBox.bottom,
+      scrollTop: scrollContainer.scrollTop,
+    };
+  });
+
+  expect(restoreMetrics.commandLineBottom).toBeLessThanOrEqual(
+    restoreMetrics.scrollBottom + 1,
   );
+  expect(restoreMetrics.scrollTop).toBeGreaterThan(0);
+
+  await page.keyboard.type("continue restored session");
+  await page.keyboard.press("Enter");
+
+  await expect(
+    page.getByText("Restored chat is ready for the next turn."),
+  ).toBeVisible();
+  await expect(page.locator("input.crt-command-line__input")).toBeEnabled();
+  await expect(page.locator("input.crt-command-line__input")).toHaveValue("");
+  expect(bootRequests).toBe(0);
 });
 
 test("renders chat API failures without crashing the terminal", async ({

--- a/virtualis-terminal/tests/unit/threads/session.test.ts
+++ b/virtualis-terminal/tests/unit/threads/session.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import { PrismaSessionStore } from "@/lib/threads/session";
+
+describe("PrismaSessionStore", () => {
+  it("refreshes session expiry from the current request time", async () => {
+    const now = new Date("2026-05-05T12:00:00.000Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    try {
+      const update = vi.fn().mockResolvedValue({});
+      const prisma = {
+        session: {
+          update,
+        },
+      } as never;
+      const store = new PrismaSessionStore(prisma);
+
+      await store.refresh("session-1");
+
+      expect(update).toHaveBeenCalledWith({
+        where: { id: "session-1" },
+        data: {
+          expiresAt: new Date("2026-05-08T12:00:00.000Z"),
+          lastActivity: now,
+        },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
## What
Preserves an active terminal session across refresh and focus recovery without replaying the boot sequence, while keeping the restored transcript readable and the live prompt immediately usable.

## Why
Refreshing after a real conversation should return the visitor to the current session, not reanimate the whole terminal from scratch or leave stale loader text behind after the next assistant turn.

## Changes
- Render persisted history as static scrollback
- Restore command history without replaying output
- Scroll restored sessions to the live prompt
- Refresh session expiry on activity
- Clear loader on streamed completion
- Cover restored follow-up turns in e2e

## Testing
- `cd virtualis-terminal && npm run check`

Fixes #3
