### PR TITLE
fix: gate terminal room by usable viewport

### DIFF
--- a/virtualis-terminal/components/MobileDenial/MobileDenial.module.css
+++ b/virtualis-terminal/components/MobileDenial/MobileDenial.module.css
@@ -95,12 +95,6 @@
   line-height: 1.65;
 }
 
-.hint {
-  color: rgba(184, 255, 187, 0.62);
-  font-size: 12px;
-  line-height: 1.45;
-}
-
 .actions {
   display: flex;
   flex-direction: column;
@@ -153,5 +147,70 @@
 @media (prefers-reduced-motion: reduce) {
   .cursor {
     animation: none;
+  }
+}
+
+@media (orientation: landscape) and (max-height: 649px) {
+  .stage {
+    align-items: center;
+    justify-items: center;
+    padding: max(12px, env(safe-area-inset-top))
+      max(18px, env(safe-area-inset-right))
+      max(12px, env(safe-area-inset-bottom))
+      max(18px, env(safe-area-inset-left));
+  }
+
+  .panel {
+    width: min(100%, 760px);
+    max-height: calc(100svh - 24px);
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(150px, 190px);
+    grid-template-rows: auto 1fr auto;
+    grid-template-areas:
+      "logo actions"
+      "status actions"
+      "prompt actions";
+    column-gap: 28px;
+    row-gap: 12px;
+    align-items: center;
+  }
+
+  .logoFrame {
+    grid-area: logo;
+    font-size: 6px;
+    line-height: 1;
+    padding: 10px 0 8px;
+  }
+
+  .status {
+    grid-area: status;
+    gap: 10px;
+    align-self: start;
+  }
+
+  .heading {
+    font-size: 14px;
+    line-height: 1.25;
+  }
+
+  .body {
+    font-size: 13px;
+    line-height: 1.45;
+  }
+
+  .actions {
+    grid-area: actions;
+    align-self: center;
+    gap: 12px;
+  }
+
+  .actions a {
+    min-height: 52px;
+    padding: 0 2px;
+  }
+
+  .prompt {
+    grid-area: prompt;
+    align-self: end;
   }
 }

--- a/virtualis-terminal/components/MobileDenial/MobileDenial.tsx
+++ b/virtualis-terminal/components/MobileDenial/MobileDenial.tsx
@@ -2,10 +2,21 @@ import styles from "./MobileDenial.module.css";
 import { COGITATIO_LOGO_TEXT } from "@/components/Terminal/config/ascii.config";
 import Link from "next/link";
 
+interface MobileDenialProps {
+  canRotateToDesktop: boolean;
+}
+
 /**
  * Replaces the terminal on small screens with an intentional denial surface.
  */
-export function MobileDenial() {
+export function MobileDenial({ canRotateToDesktop }: MobileDenialProps) {
+  const heading = canRotateToDesktop
+    ? "TRY YOUR DEVICE IN LANDSCAPE"
+    : "TERMINAL REQUIRES LARGER DISPLAY";
+  const body = canRotateToDesktop
+    ? "Cogitatio Virtualis is a CRT-style terminal experience. It is best encountered on a larger landscape display, late at night, with the lights turned down. Your device is technically compatible in landscape. Try it, if you'd like."
+    : "Cogitatio Virtualis is a CRT-style terminal experience. It is best encountered on a larger landscape display, late at night, with the lights turned down.";
+
   return (
     <main className={styles.stage} role="main">
       <div className={styles.panel}>
@@ -14,15 +25,8 @@ export function MobileDenial() {
         </pre>
 
         <div className={styles.status}>
-          <div className={styles.heading}>TERMINAL REQUIRES LARGER DISPLAY</div>
-          <p className={styles.body}>
-            Cogitatio Virtualis is a CRT-style terminal experience. It is best
-            encountered on a desktop browser, late at night, with the lights
-            turned down.
-          </p>
-          <div className={styles.hint}>
-            Open this address on a computer to begin.
-          </div>
+          <div className={styles.heading}>{heading}</div>
+          <p className={styles.body}>{body}</p>
         </div>
 
         <div className={styles.actions}>

--- a/virtualis-terminal/pages/index.tsx
+++ b/virtualis-terminal/pages/index.tsx
@@ -6,27 +6,53 @@ import { MobileDenial } from "@/components/MobileDenial/MobileDenial";
 import { RoomScene } from "@/components/RoomScene/RoomScene";
 import { VirtualisTerminal } from "@/components/Terminal/VirtualisTerminal";
 
+const MIN_DESKTOP_WIDTH = 900;
+const MIN_DESKTOP_HEIGHT = 650;
+const DESKTOP_EXPERIENCE_QUERY = `(min-width: ${MIN_DESKTOP_WIDTH}px) and (min-height: ${MIN_DESKTOP_HEIGHT}px)`;
+
+interface ExperienceState {
+  isDesktop: boolean;
+  canRotateToDesktop: boolean;
+}
+
 /**
  * Tracks the viewport class that decides which experience should mount.
  */
-function useDesktopExperience(): boolean | null {
-  const [isDesktop, setIsDesktop] = useState<boolean | null>(null);
+function useDesktopExperience(): ExperienceState | null {
+  const [experience, setExperience] = useState<ExperienceState | null>(null);
 
   useEffect(() => {
-    const query = window.matchMedia("(min-width: 769px)");
-    const update = () => setIsDesktop(query.matches);
+    const query = window.matchMedia(DESKTOP_EXPERIENCE_QUERY);
+    const update = () => {
+      const { innerWidth, innerHeight } = window;
+      const canRotateToDesktop =
+        innerWidth < innerHeight &&
+        innerHeight >= MIN_DESKTOP_WIDTH &&
+        innerWidth >= MIN_DESKTOP_HEIGHT;
+
+      setExperience({
+        isDesktop: query.matches,
+        canRotateToDesktop,
+      });
+    };
 
     update();
     query.addEventListener("change", update);
+    window.addEventListener("resize", update);
+    window.addEventListener("orientationchange", update);
 
-    return () => query.removeEventListener("change", update);
+    return () => {
+      query.removeEventListener("change", update);
+      window.removeEventListener("resize", update);
+      window.removeEventListener("orientationchange", update);
+    };
   }, []);
 
-  return isDesktop;
+  return experience;
 }
 
 export default function Home() {
-  const isDesktop = useDesktopExperience();
+  const experience = useDesktopExperience();
 
   return (
     <>
@@ -41,14 +67,16 @@ export default function Home() {
 
       <main className="home-shell">
         <div className="desktop-experience">
-          {isDesktop ? (
+          {experience?.isDesktop ? (
             <RoomScene>
               <VirtualisTerminal />
             </RoomScene>
           ) : null}
         </div>
         <div className="mobile-experience">
-          {isDesktop === false ? <MobileDenial /> : null}
+          {experience?.isDesktop === false ? (
+            <MobileDenial canRotateToDesktop={experience.canRotateToDesktop} />
+          ) : null}
         </div>
       </main>
 
@@ -67,7 +95,8 @@ export default function Home() {
           display: none;
         }
 
-        @media (max-width: 768px) {
+        @media (max-width: ${MIN_DESKTOP_WIDTH - 1}px),
+          (max-height: ${MIN_DESKTOP_HEIGHT - 1}px) {
           .desktop-experience {
             display: none;
           }

--- a/virtualis-terminal/tests/e2e/terminal.spec.ts
+++ b/virtualis-terminal/tests/e2e/terminal.spec.ts
@@ -223,7 +223,7 @@ test("preserves typed command text while editing", async ({ page }) => {
 test("keeps wrapped command input aligned and visible", async ({ page }) => {
   await mockBootSequence(page);
   await mockEmptyThread(page);
-  await page.setViewportSize({ width: 900, height: 620 });
+  await page.setViewportSize({ width: 900, height: 650 });
   await page.goto("/");
   await waitForTerminalReady(page);
 
@@ -442,7 +442,80 @@ test("shows the intentional mobile replacement surface", async ({ page }) => {
   await expect(
     page.getByText("TERMINAL REQUIRES LARGER DISPLAY"),
   ).toBeVisible();
-  await expect(page.getByText("Open this address on a computer")).toBeVisible();
+  await expect(page.getByText("TRY YOUR DEVICE IN LANDSCAPE")).toHaveCount(0);
+  await expect(
+    page.getByText(/Cogitatio Virtualis is a CRT-style terminal experience/),
+  ).toBeVisible();
   await expect(page.getByRole("link", { name: /View resume/ })).toBeVisible();
   await expect(page.locator("input.crt-command-line__input")).toBeHidden();
+});
+
+test("prompts tablet portrait users to rotate when landscape would work", async ({
+  page,
+}) => {
+  await mockBootSequence(page);
+  await mockEmptyThread(page);
+  await page.setViewportSize({ width: 768, height: 1024 });
+
+  await page.goto("/");
+
+  await expect(page.getByText("TRY YOUR DEVICE IN LANDSCAPE")).toBeVisible();
+  await expect(
+    page.getByText(/technically compatible in landscape/),
+  ).toBeVisible();
+  await expect(page.locator("input.crt-command-line__input")).toBeHidden();
+});
+
+test("keeps small landscape denial actions visible on the right", async ({
+  page,
+}) => {
+  await mockBootSequence(page);
+  await mockEmptyThread(page);
+  await page.setViewportSize({ width: 844, height: 390 });
+
+  await page.goto("/");
+
+  const heading = page.getByText("TERMINAL REQUIRES LARGER DISPLAY");
+  const resumeLink = page.getByRole("link", { name: /View resume/ });
+  const contactLink = page.getByRole("link", { name: /Contact/ });
+
+  await expect(heading).toBeVisible();
+  await expect(resumeLink).toBeVisible();
+  await expect(contactLink).toBeVisible();
+  await expect(page.getByText("TRY YOUR DEVICE IN LANDSCAPE")).toHaveCount(0);
+
+  const layout = await page.evaluate(() => {
+    const heading = document.evaluate(
+      "//*[text()='TERMINAL REQUIRES LARGER DISPLAY']",
+      document,
+      null,
+      XPathResult.FIRST_ORDERED_NODE_TYPE,
+    ).singleNodeValue as HTMLElement | null;
+    const resume = Array.from(document.querySelectorAll("a")).find((link) =>
+      link.textContent?.includes("View resume"),
+    );
+    const contact = Array.from(document.querySelectorAll("a")).find((link) =>
+      link.textContent?.includes("Contact"),
+    );
+
+    if (!heading || !resume || !contact) {
+      throw new Error("Landscape denial controls were not rendered");
+    }
+
+    const headingBox = heading.getBoundingClientRect();
+    const resumeBox = resume.getBoundingClientRect();
+    const contactBox = contact.getBoundingClientRect();
+
+    return {
+      headingRight: headingBox.right,
+      resumeLeft: resumeBox.left,
+      resumeBottom: resumeBox.bottom,
+      contactBottom: contactBox.bottom,
+      viewportHeight: window.innerHeight,
+    };
+  });
+
+  expect(layout.resumeLeft).toBeGreaterThan(layout.headingRight);
+  expect(layout.resumeBottom).toBeLessThanOrEqual(layout.viewportHeight);
+  expect(layout.contactBottom).toBeLessThanOrEqual(layout.viewportHeight);
 });


### PR DESCRIPTION
## What
This PR tightens the terminal room breakpoint so the CRT scene only mounts when the viewport has enough usable width and height, and it gives the mobile denial surface a proper landscape layout.

## Why
Small landscape devices were still receiving the desktop room scene or a portrait-stacked denial screen that ran off the viewport. Tablet portrait also needed explicit rotate guidance only when rotation would actually make the scene usable.

## Changes
- Require desktop-sized viewport
- Detect rotate-capable portrait
- Split denial copy by case
- Add landscape denial layout

## Testing
- `npm run format`
- `npm run lint`
- `npm run build:ts -- --noEmit`
- `npm run build`
- Manual local viewport checks on `http://localhost:4000`
