### PR TITLE
feat: Add self-repository terminal tools

### DIFF
--- a/virtualis-terminal/components/Terminal/VirtualisTerminal.tsx
+++ b/virtualis-terminal/components/Terminal/VirtualisTerminal.tsx
@@ -47,6 +47,52 @@ interface MountControllerOptions {
   initialThread?: ThreadMessage[];
 }
 
+const AUTO_SCROLL_BOTTOM_THRESHOLD_PX = 48;
+
+const isScrollTopNearBottom = (
+  element: HTMLElement,
+  scrollTop: number,
+): boolean => {
+  return (
+    element.scrollHeight - scrollTop - element.clientHeight <=
+    AUTO_SCROLL_BOTTOM_THRESHOLD_PX
+  );
+};
+
+const isNearScrollBottom = (element: HTMLElement): boolean => {
+  return isScrollTopNearBottom(element, element.scrollTop);
+};
+
+const HOLD_SCROLL_INTERACTION_WINDOW_MS = 1500;
+
+type ScrollTopAccessor = {
+  get: (this: Element) => number;
+  set: (this: Element, value: number) => void;
+};
+
+const findScrollTopAccessor = (
+  element: HTMLElement,
+): ScrollTopAccessor | null => {
+  let prototype: object | null = Object.getPrototypeOf(element);
+
+  while (prototype) {
+    const descriptor = Object.getOwnPropertyDescriptor(prototype, "scrollTop");
+    if (
+      typeof descriptor?.get === "function" &&
+      typeof descriptor.set === "function"
+    ) {
+      return {
+        get: descriptor.get as ScrollTopAccessor["get"],
+        set: descriptor.set as ScrollTopAccessor["set"],
+      };
+    }
+
+    prototype = Object.getPrototypeOf(prototype);
+  }
+
+  return null;
+};
+
 export const VirtualisTerminal: React.FC<VirtualisTerminalProps> = ({
   className,
   initialConfig,
@@ -63,6 +109,10 @@ export const VirtualisTerminal: React.FC<VirtualisTerminalProps> = ({
   const controllerRef = useRef<Controller | null>(null);
   const clearTerminalRef = useRef(async (): Promise<void> => {});
   const surfaceRef = useRef<HTMLDivElement>(null);
+  const shouldAutoScrollRef = useRef(true);
+  const heldScrollTopRef = useRef(0);
+  const lastUserScrollIntentRef = useRef(0);
+  const allowProgrammaticScrollRef = useRef(false);
   const [controller, setController] = useState<Controller | null>(null);
   const [restoredThread, setRestoredThread] = useState<ThreadMessage[]>([]);
 
@@ -368,38 +418,199 @@ export const VirtualisTerminal: React.FC<VirtualisTerminalProps> = ({
     const surface = surfaceRef.current;
     if (!surface) return;
 
-    const scrollTerminalToBottom = () => {
-      const scrollContainer = surface.querySelector<HTMLElement>(
-        ".crt-terminal__overflow-container",
+    let activeScrollContainer: HTMLElement | null = null;
+    let restoreScrollTopGuard: (() => void) | null = null;
+
+    const markUserScrollIntent = () => {
+      lastUserScrollIntentRef.current = window.performance.now();
+    };
+
+    const hadRecentUserScrollIntent = () => {
+      return (
+        window.performance.now() - lastUserScrollIntentRef.current <=
+        HOLD_SCROLL_INTERACTION_WINDOW_MS
       );
-      if (scrollContainer) {
-        scrollContainer.scrollTop = scrollContainer.scrollHeight;
+    };
+
+    const withProgrammaticScroll = (operation: () => void) => {
+      allowProgrammaticScrollRef.current = true;
+      try {
+        operation();
+      } finally {
+        allowProgrammaticScrollRef.current = false;
       }
     };
 
-    const scheduleScrollCommandLineIntoView = () => {
-      scrollTerminalToBottom();
-      window.requestAnimationFrame(() => {
-        scrollTerminalToBottom();
+    const installScrollTopGuard = (scrollContainer: HTMLElement) => {
+      const accessor = findScrollTopAccessor(scrollContainer);
+      if (!accessor) {
+        return null;
+      }
+
+      Object.defineProperty(scrollContainer, "scrollTop", {
+        configurable: true,
+        get() {
+          return accessor.get.call(scrollContainer);
+        },
+        set(nextScrollTop: number) {
+          const wantsBottom = isScrollTopNearBottom(
+            scrollContainer,
+            nextScrollTop,
+          );
+
+          if (
+            !allowProgrammaticScrollRef.current &&
+            !shouldAutoScrollRef.current &&
+            wantsBottom
+          ) {
+            accessor.set.call(scrollContainer, heldScrollTopRef.current);
+            return;
+          }
+
+          accessor.set.call(scrollContainer, nextScrollTop);
+        },
+      });
+
+      return () => {
+        Reflect.deleteProperty(scrollContainer, "scrollTop");
+      };
+    };
+
+    const attachScrollListeners = (scrollContainer: HTMLElement) => {
+      scrollContainer.addEventListener("scroll", updateAutoScrollState, {
+        passive: true,
+      });
+      scrollContainer.addEventListener("wheel", markUserScrollIntent, {
+        passive: true,
+      });
+      scrollContainer.addEventListener("touchmove", markUserScrollIntent, {
+        passive: true,
+      });
+      scrollContainer.addEventListener("pointerdown", markUserScrollIntent, {
+        passive: true,
       });
     };
 
-    const observer = new MutationObserver(scheduleScrollCommandLineIntoView);
+    const detachScrollListeners = (scrollContainer: HTMLElement) => {
+      scrollContainer.removeEventListener("scroll", updateAutoScrollState);
+      scrollContainer.removeEventListener("wheel", markUserScrollIntent);
+      scrollContainer.removeEventListener("touchmove", markUserScrollIntent);
+      scrollContainer.removeEventListener("pointerdown", markUserScrollIntent);
+    };
+
+    const updateAutoScrollState = () => {
+      if (!activeScrollContainer) return;
+
+      if (!hadRecentUserScrollIntent()) {
+        return;
+      }
+
+      shouldAutoScrollRef.current = isNearScrollBottom(activeScrollContainer);
+      if (!shouldAutoScrollRef.current) {
+        heldScrollTopRef.current = activeScrollContainer.scrollTop;
+      }
+    };
+
+    const resolveScrollContainer = () => {
+      const scrollContainer = surface.querySelector<HTMLElement>(
+        ".crt-terminal__overflow-container",
+      );
+
+      if (scrollContainer === activeScrollContainer) {
+        return activeScrollContainer;
+      }
+
+      if (activeScrollContainer) {
+        detachScrollListeners(activeScrollContainer);
+      }
+      restoreScrollTopGuard?.();
+      activeScrollContainer = scrollContainer;
+      if (activeScrollContainer) {
+        attachScrollListeners(activeScrollContainer);
+        restoreScrollTopGuard = installScrollTopGuard(activeScrollContainer);
+      }
+
+      return activeScrollContainer;
+    };
+
+    const scrollTerminalToBottom = () => {
+      const scrollContainer = resolveScrollContainer();
+      if (scrollContainer) {
+        withProgrammaticScroll(() => {
+          scrollContainer.scrollTop = scrollContainer.scrollHeight;
+        });
+      }
+    };
+
+    const preserveHeldScrollPosition = () => {
+      const scrollContainer = resolveScrollContainer();
+      if (!scrollContainer) return;
+
+      withProgrammaticScroll(() => {
+        scrollContainer.scrollTop = heldScrollTopRef.current;
+      });
+      window.requestAnimationFrame(() => {
+        if (!shouldAutoScrollRef.current) {
+          withProgrammaticScroll(() => {
+            scrollContainer.scrollTop = heldScrollTopRef.current;
+          });
+        }
+      });
+    };
+
+    const scheduleScrollCommandLineIntoView = (force = false) => {
+      if (force) {
+        shouldAutoScrollRef.current = true;
+      }
+
+      if (!shouldAutoScrollRef.current) {
+        preserveHeldScrollPosition();
+        return;
+      }
+
+      scrollTerminalToBottom();
+      window.requestAnimationFrame(() => {
+        if (shouldAutoScrollRef.current) {
+          scrollTerminalToBottom();
+        }
+      });
+    };
+
+    const forceScrollFromCommandInput = (event: Event) => {
+      const target = event.target;
+      const isCommandInput =
+        target instanceof Element &&
+        Boolean(target.closest(".crt-command-line__input"));
+
+      if (isCommandInput) {
+        scheduleScrollCommandLineIntoView(true);
+      }
+    };
+
+    const observer = new MutationObserver(() => {
+      scheduleScrollCommandLineIntoView();
+    });
     observer.observe(surface, {
       characterData: true,
       childList: true,
       subtree: true,
     });
 
-    surface.addEventListener("input", scheduleScrollCommandLineIntoView);
-    surface.addEventListener("keydown", scheduleScrollCommandLineIntoView);
-    surface.addEventListener("keyup", scheduleScrollCommandLineIntoView);
+    resolveScrollContainer();
+    scheduleScrollCommandLineIntoView(true);
 
+    surface.addEventListener("input", forceScrollFromCommandInput);
+    surface.addEventListener("keydown", forceScrollFromCommandInput);
+    surface.addEventListener("keyup", forceScrollFromCommandInput);
     return () => {
       observer.disconnect();
-      surface.removeEventListener("input", scheduleScrollCommandLineIntoView);
-      surface.removeEventListener("keydown", scheduleScrollCommandLineIntoView);
-      surface.removeEventListener("keyup", scheduleScrollCommandLineIntoView);
+      if (activeScrollContainer) {
+        detachScrollListeners(activeScrollContainer);
+      }
+      restoreScrollTopGuard?.();
+      surface.removeEventListener("input", forceScrollFromCommandInput);
+      surface.removeEventListener("keydown", forceScrollFromCommandInput);
+      surface.removeEventListener("keyup", forceScrollFromCommandInput);
     };
   }, []);
 

--- a/virtualis-terminal/components/Terminal/utils/printUtils.ts
+++ b/virtualis-terminal/components/Terminal/utils/printUtils.ts
@@ -27,6 +27,10 @@ interface BaseWordConfig {
   dataAttribute?: string;
 }
 
+export const TERMINAL_TEXT_COLUMNS = 68;
+
+const BLANK_LINE = "\u00A0";
+
 export type WordConfig = BaseWordConfig &
   (
     | { type: "text" }
@@ -93,6 +97,61 @@ export const sendMultiLine = (
   return lines.map((line) => createLine(line.words, line.options));
 };
 
+const getContinuationPrefix = (line: string): string => {
+  const prefix = line.match(/^(\s*(?:[-*]\s+|\d+\.\s+|>\s+)?)/)?.[1] ?? "";
+  return " ".repeat(prefix.length);
+};
+
+const wrapTerminalLine = (
+  line: string,
+  width = TERMINAL_TEXT_COLUMNS,
+): string[] => {
+  if (!line.trim()) {
+    return [BLANK_LINE];
+  }
+
+  if (line.length <= width) {
+    return [line];
+  }
+
+  const initialPrefix =
+    line.match(/^(\s*(?:[-*]\s+|\d+\.\s+|>\s+)?)/)?.[1] ?? "";
+  const continuationPrefix = getContinuationPrefix(line);
+  const wrapped: string[] = [];
+  let prefix = initialPrefix;
+  let remaining = line.slice(initialPrefix.length);
+
+  while (prefix.length + remaining.length > width) {
+    const availableWidth = Math.max(1, width - prefix.length);
+    let breakIndex = remaining.lastIndexOf(" ", availableWidth);
+
+    if (breakIndex <= 0) {
+      breakIndex = Math.min(availableWidth, remaining.length);
+    }
+
+    const segment = remaining.slice(0, breakIndex).trimEnd();
+    wrapped.push(`${prefix}${segment}`);
+    remaining = remaining.slice(breakIndex).trimStart();
+    prefix = continuationPrefix;
+  }
+
+  if (remaining || wrapped.length === 0) {
+    wrapped.push(`${prefix}${remaining}`);
+  }
+
+  return wrapped;
+};
+
+export const wrapTerminalText = (
+  text: string,
+  width = TERMINAL_TEXT_COLUMNS,
+): string[] => {
+  return text
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .flatMap((line) => wrapTerminalLine(line, width));
+};
+
 export const sendMessage = (
   text: string,
   role: "system" | "info" | "user" | "assistant" = "user", // default role is 'user'
@@ -100,9 +159,11 @@ export const sendMessage = (
   const wordClassName = `message-${role}`;
   const lineClassName = `line-${role}`;
 
-  return sendLine(
-    [{ type: "text", characters: text, className: wordClassName }],
-    { lineClassName },
+  return sendMultiLine(
+    wrapTerminalText(text).map((line) => ({
+      words: [{ type: "text", characters: line, className: wordClassName }],
+      options: { lineClassName },
+    })),
   );
 };
 

--- a/virtualis-terminal/lib/api/cogitator-claude.ts
+++ b/virtualis-terminal/lib/api/cogitator-claude.ts
@@ -168,6 +168,55 @@ export class ClaudeAPI {
           properties: {},
         },
       },
+      {
+        name: "self_repo_current_commit",
+        description:
+          "return the current git commit for the deployed Cogitatio Virtualis repository checkout.",
+        input_schema: {
+          type: "object",
+          properties: {},
+        },
+      },
+      {
+        name: "self_repo_list_files",
+        description:
+          "list readable tracked files in the Cogitatio Virtualis repository. Optional prefix narrows to a repo-relative path prefix.",
+        input_schema: {
+          type: "object",
+          properties: {
+            prefix: { type: "string" },
+            limit: { type: "number" },
+          },
+        },
+      },
+      {
+        name: "self_repo_read_file",
+        description:
+          "read a bounded line range from a readable tracked file in the Cogitatio Virtualis repository at HEAD.",
+        input_schema: {
+          type: "object",
+          properties: {
+            path: { type: "string" },
+            start_line: { type: "number" },
+            end_line: { type: "number" },
+          },
+          required: ["path"],
+        },
+      },
+      {
+        name: "self_repo_search",
+        description:
+          "literal-search readable tracked files in the Cogitatio Virtualis repository. Optional path_prefix narrows the search.",
+        input_schema: {
+          type: "object",
+          properties: {
+            query: { type: "string" },
+            path_prefix: { type: "string" },
+            limit: { type: "number" },
+          },
+          required: ["query"],
+        },
+      },
     ];
   }
 

--- a/virtualis-terminal/lib/api/selfRepo.ts
+++ b/virtualis-terminal/lib/api/selfRepo.ts
@@ -1,0 +1,351 @@
+import { execFile } from "node:child_process";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const MAX_LIST_LIMIT = 200;
+const DEFAULT_LIST_LIMIT = 80;
+const MAX_SEARCH_LIMIT = 50;
+const DEFAULT_SEARCH_LIMIT = 20;
+const MAX_READ_LINES = 300;
+const MAX_READ_CHARS = 20_000;
+
+export interface SelfRepoListInput {
+  prefix?: string;
+  limit?: number;
+}
+
+export interface SelfRepoReadInput {
+  path: string;
+  startLine?: number;
+  endLine?: number;
+}
+
+export interface SelfRepoSearchInput {
+  query: string;
+  pathPrefix?: string;
+  limit?: number;
+}
+
+export interface SelfRepoFileSnippet {
+  path: string;
+  startLine: number;
+  endLine: number;
+  content: string;
+  truncated: boolean;
+  commit: string;
+}
+
+export interface SelfRepoSearchMatch {
+  path: string;
+  line: number;
+  text: string;
+}
+
+function clampLimit(limit: number | undefined, fallback: number, max: number) {
+  if (!limit) return fallback;
+  return Math.min(Math.max(Math.floor(limit), 1), max);
+}
+
+function normalizeRepoPath(inputPath: string): string {
+  if (inputPath.includes("\0")) {
+    throw new Error("Repository path cannot contain NUL bytes.");
+  }
+
+  const normalized = path.posix.normalize(inputPath.replaceAll("\\", "/"));
+  if (
+    normalized === "." ||
+    normalized.startsWith("../") ||
+    normalized === ".." ||
+    path.posix.isAbsolute(normalized)
+  ) {
+    throw new Error("Repository path must be relative to the repo root.");
+  }
+
+  return normalized;
+}
+
+function isDeniedPath(repoPath: string): boolean {
+  const segments = repoPath.split("/");
+  const basename = segments.at(-1) ?? "";
+
+  return (
+    basename.startsWith(".env") ||
+    basename.endsWith(".db") ||
+    segments.includes("sessions") ||
+    repoPath.startsWith("virtualis-terminal/lib/generated/")
+  );
+}
+
+function formatListMessage(
+  files: string[],
+  commit: string,
+  truncated: boolean,
+) {
+  const suffix = truncated
+    ? "\n\n[truncated: narrow prefix or increase later]"
+    : "";
+  return `Self repository at ${commit}:\n${files.join("\n")}${suffix}`;
+}
+
+function formatReadMessage(snippet: SelfRepoFileSnippet) {
+  const suffix = snippet.truncated ? "\n\n[truncated]" : "";
+  return `Read ${snippet.path}:${snippet.startLine}-${snippet.endLine} at ${snippet.commit}\n\n${snippet.content}${suffix}`;
+}
+
+function formatSearchMessage(
+  matches: SelfRepoSearchMatch[],
+  query: string,
+  commit: string,
+  truncated: boolean,
+) {
+  if (!matches.length) {
+    return `No self-repository matches for "${query}" at ${commit}.`;
+  }
+
+  const rendered = matches
+    .map((match) => `${match.path}:${match.line}: ${match.text}`)
+    .join("\n");
+  const suffix = truncated ? "\n\n[truncated: narrow path_prefix]" : "";
+  return `Self-repository matches for "${query}" at ${commit}:\n${rendered}${suffix}`;
+}
+
+/**
+ * Provides read-only access to the current deployed repository checkout.
+ */
+export class SelfRepoReader {
+  private repoRoot: string | null = null;
+
+  async currentCommit(): Promise<string> {
+    const { stdout } = await this.gitText(["rev-parse", "HEAD"]);
+    return stdout.trim();
+  }
+
+  /**
+   * Lists readable repository files tracked at HEAD under an optional prefix.
+   */
+  async listFiles(input: SelfRepoListInput = {}) {
+    const prefix = input.prefix ? normalizeRepoPath(input.prefix) : "";
+    const limit = clampLimit(input.limit, DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT);
+    const [commit, files] = await Promise.all([
+      this.currentCommit(),
+      this.trackedFiles(),
+    ]);
+    const filtered = files.filter((file) => !prefix || file.startsWith(prefix));
+    const visible = filtered.slice(0, limit);
+
+    return {
+      success: true,
+      message: formatListMessage(
+        visible,
+        commit,
+        filtered.length > visible.length,
+      ),
+      data: {
+        commit,
+        files: visible,
+        truncated: filtered.length > visible.length,
+      },
+    };
+  }
+
+  /**
+   * Reads a tracked file through git at HEAD, returning a bounded line range.
+   */
+  async readFile(input: SelfRepoReadInput) {
+    const repoPath = normalizeRepoPath(input.path);
+    await this.assertReadableTrackedFile(repoPath);
+
+    const commit = await this.currentCommit();
+    const { stdout } = await this.gitText(["show", `HEAD:${repoPath}`], {
+      maxBuffer: 2 * 1024 * 1024,
+    });
+    const lines = stdout.split(/\r?\n/);
+    const requestedStart = input.startLine ?? 1;
+    const requestedEnd = input.endLine ?? requestedStart + MAX_READ_LINES - 1;
+    const startLine = Math.max(1, Math.floor(requestedStart));
+    const endLine = Math.min(
+      lines.length,
+      Math.max(startLine, Math.floor(requestedEnd)),
+      startLine + MAX_READ_LINES - 1,
+    );
+    const content = lines.slice(startLine - 1, endLine).join("\n");
+    const truncated = endLine < lines.length || content.length > MAX_READ_CHARS;
+    const snippet: SelfRepoFileSnippet = {
+      path: repoPath,
+      startLine,
+      endLine,
+      content: content.slice(0, MAX_READ_CHARS),
+      truncated,
+      commit,
+    };
+
+    return {
+      success: true,
+      message: formatReadMessage(snippet),
+      data: snippet,
+    };
+  }
+
+  /**
+   * Searches readable files tracked at HEAD using literal git grep.
+   */
+  async search(input: SelfRepoSearchInput) {
+    const query = input.query.trim();
+    if (!query || query.includes("\0") || query.includes("\n")) {
+      throw new Error("Search query must be a single non-empty line.");
+    }
+
+    const pathPrefix = input.pathPrefix
+      ? normalizeRepoPath(input.pathPrefix)
+      : "";
+    const limit = clampLimit(
+      input.limit,
+      DEFAULT_SEARCH_LIMIT,
+      MAX_SEARCH_LIMIT,
+    );
+    const [commit, files] = await Promise.all([
+      this.currentCommit(),
+      this.trackedFiles(),
+    ]);
+    const searchableFiles = files.filter(
+      (file) => !pathPrefix || file.startsWith(pathPrefix),
+    );
+
+    if (!searchableFiles.length) {
+      return {
+        success: true,
+        message: `No readable self-repository files under "${pathPrefix}".`,
+        data: { commit, matches: [], truncated: false },
+      };
+    }
+
+    const grepArgs = [
+      "grep",
+      "-n",
+      "-I",
+      "-F",
+      "--",
+      query,
+      "HEAD",
+      ...searchableFiles,
+    ];
+
+    let stdout = "";
+    try {
+      const result = await this.gitText(grepArgs, {
+        maxBuffer: 2 * 1024 * 1024,
+      });
+      stdout = result.stdout;
+    } catch (error) {
+      if (this.isGitNoMatch(error)) {
+        return {
+          success: true,
+          message: formatSearchMessage([], query, commit, false),
+          data: { commit, matches: [], truncated: false },
+        };
+      }
+
+      throw error;
+    }
+
+    const allMatches = stdout
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map((line) => {
+        const normalizedLine = line.startsWith("HEAD:")
+          ? line.slice("HEAD:".length)
+          : line;
+        const firstColon = normalizedLine.indexOf(":");
+        const secondColon = normalizedLine.indexOf(":", firstColon + 1);
+        return {
+          path: normalizedLine.slice(0, firstColon),
+          line: Number(normalizedLine.slice(firstColon + 1, secondColon)),
+          text: normalizedLine.slice(secondColon + 1),
+        };
+      });
+    const matches = allMatches.slice(0, limit);
+
+    return {
+      success: true,
+      message: formatSearchMessage(
+        matches,
+        query,
+        commit,
+        allMatches.length > matches.length,
+      ),
+      data: {
+        commit,
+        matches,
+        truncated: allMatches.length > matches.length,
+      },
+    };
+  }
+
+  private async trackedFiles(): Promise<string[]> {
+    const { stdout } = await this.gitBuffer(
+      ["ls-tree", "-r", "-z", "--name-only", "HEAD"],
+      {
+        maxBuffer: 2 * 1024 * 1024,
+      },
+    );
+    return stdout
+      .toString("utf8")
+      .split("\0")
+      .filter(Boolean)
+      .filter((file) => !isDeniedPath(file));
+  }
+
+  private async assertReadableTrackedFile(repoPath: string): Promise<void> {
+    const files = await this.trackedFiles();
+    if (!files.includes(repoPath)) {
+      throw new Error(`Path is not a readable tracked file: ${repoPath}`);
+    }
+  }
+
+  private async gitText(
+    args: string[],
+    options: { maxBuffer?: number } = {},
+  ): Promise<{ stdout: string; stderr: string }> {
+    const cwd = await this.getRepoRoot();
+    return (await execFileAsync("git", ["-C", cwd, ...args], {
+      encoding: "utf8",
+      maxBuffer: options.maxBuffer ?? 1024 * 1024,
+    })) as { stdout: string; stderr: string };
+  }
+
+  private async gitBuffer(
+    args: string[],
+    options: { maxBuffer?: number } = {},
+  ): Promise<{ stdout: Buffer; stderr: Buffer }> {
+    const cwd = await this.getRepoRoot();
+    return (await execFileAsync("git", ["-C", cwd, ...args], {
+      encoding: "buffer",
+      maxBuffer: options.maxBuffer ?? 1024 * 1024,
+    })) as { stdout: Buffer; stderr: Buffer };
+  }
+
+  private async getRepoRoot(): Promise<string> {
+    if (this.repoRoot) return this.repoRoot;
+
+    const { stdout } = await execFileAsync(
+      "git",
+      ["-C", process.cwd(), "rev-parse", "--show-toplevel"],
+      { encoding: "utf8" },
+    );
+    this.repoRoot = stdout.trim();
+    return this.repoRoot;
+  }
+
+  private isGitNoMatch(error: unknown): boolean {
+    return (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      error.code === 1
+    );
+  }
+}
+
+export const selfRepoReader = new SelfRepoReader();

--- a/virtualis-terminal/lib/chat/claudeToolDispatch.ts
+++ b/virtualis-terminal/lib/chat/claudeToolDispatch.ts
@@ -4,6 +4,7 @@ import {
   type HardCommandOperations,
   type HardCommandResponse,
 } from "@/lib/chat/hardCommands";
+import { selfRepoReader } from "@/lib/api/selfRepo";
 import type { ToolUseBlock } from "@/lib/chat/messageCodec";
 import { DocumentType, OtherSubType, ProjectSubType } from "@/types/documents";
 
@@ -56,6 +57,56 @@ const searchInput = z.object({
   query: z.string().min(1),
 });
 
+const selfRepoListInput = z.object({
+  prefix: z.string().min(1).optional(),
+  limit: z.number().int().positive().optional(),
+});
+
+const selfRepoReadInput = z.object({
+  path: z.string().min(1),
+  start_line: z.number().int().positive().optional(),
+  end_line: z.number().int().positive().optional(),
+});
+
+const selfRepoSearchInput = z.object({
+  query: z.string().min(1),
+  path_prefix: z.string().min(1).optional(),
+  limit: z.number().int().positive().optional(),
+});
+
+export interface ClaudeToolOperations extends HardCommandOperations {
+  runSelfRepoCurrentCommit(): Promise<HardCommandResponse>;
+  runSelfRepoList(input: {
+    prefix?: string;
+    limit?: number;
+  }): Promise<HardCommandResponse>;
+  runSelfRepoReadFile(input: {
+    path: string;
+    startLine?: number;
+    endLine?: number;
+  }): Promise<HardCommandResponse>;
+  runSelfRepoSearch(input: {
+    query: string;
+    pathPrefix?: string;
+    limit?: number;
+  }): Promise<HardCommandResponse>;
+}
+
+export const claudeToolOperations: ClaudeToolOperations = {
+  ...hardCommandOperations,
+  async runSelfRepoCurrentCommit() {
+    const commit = await selfRepoReader.currentCommit();
+    return {
+      success: true,
+      message: `Self repository HEAD is ${commit}.`,
+      data: { commit },
+    };
+  },
+  runSelfRepoList: (input) => selfRepoReader.listFiles(input),
+  runSelfRepoReadFile: (input) => selfRepoReader.readFile(input),
+  runSelfRepoSearch: (input) => selfRepoReader.search(input),
+};
+
 function invalidToolInput(toolUse: ToolUseBlock, error: unknown): never {
   if (error instanceof z.ZodError) {
     const issueSummary = error.issues
@@ -72,7 +123,7 @@ function invalidToolInput(toolUse: ToolUseBlock, error: unknown): never {
  */
 export async function dispatchClaudeToolUse(
   toolUse: ToolUseBlock,
-  operations: HardCommandOperations = hardCommandOperations,
+  operations: ClaudeToolOperations = claudeToolOperations,
 ): Promise<HardCommandResponse | null> {
   try {
     switch (toolUse.name) {
@@ -119,6 +170,32 @@ export async function dispatchClaudeToolUse(
 
       case "status_command":
         return await operations.runStatusCommand();
+
+      case "self_repo_current_commit":
+        return await operations.runSelfRepoCurrentCommit();
+
+      case "self_repo_list_files": {
+        const input = selfRepoListInput.parse(toolUse.input);
+        return await operations.runSelfRepoList(input);
+      }
+
+      case "self_repo_read_file": {
+        const input = selfRepoReadInput.parse(toolUse.input);
+        return await operations.runSelfRepoReadFile({
+          path: input.path,
+          startLine: input.start_line,
+          endLine: input.end_line,
+        });
+      }
+
+      case "self_repo_search": {
+        const input = selfRepoSearchInput.parse(toolUse.input);
+        return await operations.runSelfRepoSearch({
+          query: input.query,
+          pathPrefix: input.path_prefix,
+          limit: input.limit,
+        });
+      }
 
       default:
         return null;

--- a/virtualis-terminal/lib/chat/messageCodec.ts
+++ b/virtualis-terminal/lib/chat/messageCodec.ts
@@ -97,6 +97,86 @@ export function isPureToolResult(message: ThreadMessage): boolean {
   );
 }
 
+function assistantToolUseIds(message: ThreadMessage): string[] {
+  if (message.role !== "assistant") {
+    return [];
+  }
+
+  return message.content
+    .filter((block): block is ToolUseBlock => block.type === "tool_use")
+    .map((block) => block.id);
+}
+
+function toolResultIds(message: ThreadMessage): string[] {
+  if (!isPureToolResult(message)) {
+    return [];
+  }
+
+  return message.content
+    .filter((block): block is ToolResultBlock => block.type === "tool_result")
+    .map((block) => block.tool_use_id);
+}
+
+function includesEveryId(resultIds: string[], toolUseIds: string[]): boolean {
+  return toolUseIds.every((id) => resultIds.includes(id));
+}
+
+function removeToolUseBlocks(message: ThreadMessage): ThreadMessage | null {
+  const content = message.content.filter((block) => block.type !== "tool_use");
+  if (!content.length) {
+    return null;
+  }
+
+  return { ...message, content };
+}
+
+/**
+ * Reconstructs Claude's required assistant-tool/user-result adjacency before
+ * resending stored thread history to Anthropic.
+ */
+export function normalizeToolResultAdjacency(
+  messages: ThreadMessage[],
+): ThreadMessage[] {
+  const normalized: ThreadMessage[] = [];
+  const used = new Set<number>();
+
+  for (const [index, message] of messages.entries()) {
+    if (used.has(index) || isPureToolResult(message)) {
+      continue;
+    }
+
+    const toolUseIds = assistantToolUseIds(message);
+    if (!toolUseIds.length) {
+      normalized.push(message);
+      used.add(index);
+      continue;
+    }
+
+    const resultIndex = messages.findIndex((candidate, candidateIndex) => {
+      if (candidateIndex === index || used.has(candidateIndex)) {
+        return false;
+      }
+
+      return includesEveryId(toolResultIds(candidate), toolUseIds);
+    });
+
+    if (resultIndex === -1) {
+      const sanitized = removeToolUseBlocks(message);
+      if (sanitized) {
+        normalized.push(sanitized);
+      }
+      used.add(index);
+      continue;
+    }
+
+    normalized.push(message, messages[resultIndex]);
+    used.add(index);
+    used.add(resultIndex);
+  }
+
+  return normalized;
+}
+
 /**
  * Repairs a single text block when Claude emits only one side of the reply tag.
  */

--- a/virtualis-terminal/lib/chat/threadStore.ts
+++ b/virtualis-terminal/lib/chat/threadStore.ts
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/threads/prisma";
 import {
   encodeContentBlocks,
   isPureToolResult,
+  normalizeToolResultAdjacency,
   parseStoredMessage,
   type ContentBlock,
   type ThreadMessage,
@@ -16,11 +17,19 @@ export async function storeMessage(
   role: ThreadRole,
   blocks: ContentBlock[],
 ): Promise<void> {
+  const lastMessage = await prisma.threadMessage.findFirst({
+    where: { sessionId },
+    orderBy: { timestamp: "desc" },
+  });
+  const lastTimestamp = lastMessage?.timestamp.getTime() ?? 0;
+  const timestamp = new Date(Math.max(Date.now(), lastTimestamp + 1));
+
   await prisma.threadMessage.create({
     data: {
       sessionId,
       role,
       content: encodeContentBlocks(blocks),
+      timestamp,
     },
   });
 }
@@ -71,8 +80,8 @@ export async function getThreadMessages(
 ): Promise<ThreadMessage[]> {
   const dbMessages = await prisma.threadMessage.findMany({
     where: { sessionId },
-    orderBy: { timestamp: "asc" },
+    orderBy: [{ timestamp: "asc" }, { id: "asc" }],
   });
 
-  return dbMessages.map(parseStoredMessage);
+  return normalizeToolResultAdjacency(dbMessages.map(parseStoredMessage));
 }

--- a/virtualis-terminal/lib/prompts/cogito-sequence.md
+++ b/virtualis-terminal/lib/prompts/cogito-sequence.md
@@ -134,6 +134,12 @@ YOU DO NOT NEED TO DOUBLE ESCAPE NEWLINE CHARACTERS.
   - none - a raw similarity comparison
   - query - where your input query is an actual question, the vector database will attempt to reconfigure proximity for responsiveness
   - document - effectively HyDE, looking for similarity to a desired chunk that you'd like to find in the vector database
+- self_repo_current_commit - get the current git commit for the deployed Cogitatio Virtualis repository
+- self_repo_list_files - list readable tracked files in your own repository; use `prefix` to narrow the tree before reading
+- self_repo_search - literal-search readable tracked files in your own repository; use `path_prefix` to narrow the search surface
+- self_repo_read_file - read bounded line ranges from a readable tracked file in your own repository at HEAD
+
+Use the self-repository tools only when the user asks about Cogitatio Virtualis itself, its implementation, or its deployed code. Treat those tool results as live code evidence, not as Eric's curated professional corpus. Do not imply that you can write files, deploy, restart services, read environment variables, or inspect untracked runtime files.
 
 ---
 

--- a/virtualis-terminal/tests/e2e/terminal.spec.ts
+++ b/virtualis-terminal/tests/e2e/terminal.spec.ts
@@ -147,6 +147,16 @@ async function waitForTerminalReady(page: Page) {
   });
 }
 
+async function waitForAnimationFrames(page: Page, count = 2) {
+  await page.evaluate(async (frameCount) => {
+    for (let index = 0; index < frameCount; index += 1) {
+      await new Promise<void>((resolve) => {
+        window.requestAnimationFrame(() => resolve());
+      });
+    }
+  }, count);
+}
+
 test("boots the terminal shell without backend failures", async ({ page }) => {
   await mockBootSequence(page);
   await mockEmptyThread(page);
@@ -176,9 +186,10 @@ test("submits a terminal command and renders the streamed response", async ({
 
   await expect(
     page.getByText(
-      "Cogitatio Terminal is connected to Cogitatio Server - Systems Nominal.",
+      "Cogitatio Terminal is connected to Cogitatio Server - Systems",
     ),
   ).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText("Nominal.")).toBeVisible({ timeout: 10_000 });
 });
 
 test("renders ambient progress events during a long response", async ({
@@ -268,6 +279,133 @@ test("keeps wrapped command input aligned and visible", async ({ page }) => {
   expect(metrics.inputHeight).toBeGreaterThan(24);
   expect(metrics.inputBottom).toBeLessThanOrEqual(metrics.scrollBottom + 1);
   expect(metrics.scrollTop).toBeGreaterThan(0);
+});
+
+test("lets users hold scrollback while new terminal output arrives", async ({
+  page,
+}) => {
+  await mockBootSequence(page);
+  await mockEmptyThread(page);
+  await page.setViewportSize({ width: 900, height: 650 });
+  await page.goto("/");
+  await waitForTerminalReady(page);
+
+  await page.evaluate(() => {
+    const scrollContainer = document.querySelector<HTMLElement>(
+      ".crt-terminal__overflow-container",
+    );
+
+    if (!scrollContainer) {
+      throw new Error("Terminal scroll container was not rendered");
+    }
+
+    for (let index = 0; index < 80; index += 1) {
+      const line = document.createElement("div");
+      line.textContent = `scrollback filler ${index}`;
+      line.style.minHeight = "24px";
+      scrollContainer.appendChild(line);
+    }
+  });
+
+  await page.waitForFunction(() => {
+    const scrollContainer = document.querySelector<HTMLElement>(
+      ".crt-terminal__overflow-container",
+    );
+    return (
+      scrollContainer &&
+      scrollContainer.scrollHeight > scrollContainer.clientHeight &&
+      scrollContainer.scrollTop > 0
+    );
+  });
+
+  await page.evaluate(() => {
+    const scrollContainer = document.querySelector<HTMLElement>(
+      ".crt-terminal__overflow-container",
+    );
+
+    if (!scrollContainer) {
+      throw new Error("Terminal scroll container was not rendered");
+    }
+
+    scrollContainer.dispatchEvent(new WheelEvent("wheel", { deltaY: -200 }));
+    scrollContainer.scrollTop = 0;
+    scrollContainer.dispatchEvent(new Event("scroll"));
+
+    const line = document.createElement("div");
+    line.textContent = "output while reader is reviewing scrollback";
+    line.style.minHeight = "24px";
+    scrollContainer.appendChild(line);
+    scrollContainer.scrollTop = scrollContainer.scrollHeight;
+    scrollContainer.dispatchEvent(new Event("scroll"));
+  });
+  await waitForAnimationFrames(page);
+
+  const heldScrollTop = await page.evaluate(() => {
+    const scrollContainer = document.querySelector<HTMLElement>(
+      ".crt-terminal__overflow-container",
+    );
+
+    if (!scrollContainer) {
+      throw new Error("Terminal scroll container was not rendered");
+    }
+
+    return scrollContainer.scrollTop;
+  });
+
+  expect(heldScrollTop).toBeLessThanOrEqual(2);
+
+  const scrollBox = await page
+    .locator(".crt-terminal__overflow-container")
+    .boundingBox();
+  expect(scrollBox).not.toBeNull();
+  await page.mouse.move(
+    scrollBox!.x + scrollBox!.width / 2,
+    scrollBox!.y + scrollBox!.height / 2,
+  );
+  await page.mouse.wheel(0, 5000);
+  await page.waitForFunction(() => {
+    const scrollContainer = document.querySelector<HTMLElement>(
+      ".crt-terminal__overflow-container",
+    );
+    return (
+      scrollContainer &&
+      scrollContainer.scrollHeight -
+        scrollContainer.scrollTop -
+        scrollContainer.clientHeight <=
+        48
+    );
+  });
+
+  const resumedDistanceFromBottom = await page.evaluate(() => {
+    const scrollContainer = document.querySelector<HTMLElement>(
+      ".crt-terminal__overflow-container",
+    );
+
+    if (!scrollContainer) {
+      throw new Error("Terminal scroll container was not rendered");
+    }
+
+    const line = document.createElement("div");
+    line.textContent = "output after reader returned to the prompt";
+    line.style.minHeight = "24px";
+    scrollContainer.appendChild(line);
+    scrollContainer.scrollTop = scrollContainer.scrollHeight;
+    scrollContainer.dispatchEvent(new Event("scroll"));
+
+    return new Promise<number>((resolve) => {
+      window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => {
+          resolve(
+            scrollContainer.scrollHeight -
+              scrollContainer.scrollTop -
+              scrollContainer.clientHeight,
+          );
+        });
+      });
+    });
+  });
+
+  expect(resumedDistanceFromBottom).toBeLessThanOrEqual(48);
 });
 
 test("restores an existing session without replaying boot", async ({

--- a/virtualis-terminal/tests/unit/api/selfRepo.test.ts
+++ b/virtualis-terminal/tests/unit/api/selfRepo.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { SelfRepoReader } from "@/lib/api/selfRepo";
+
+describe("SelfRepoReader", () => {
+  it("reads bounded snippets from tracked repository files", async () => {
+    const reader = new SelfRepoReader();
+
+    const result = await reader.readFile({
+      path: "virtualis-terminal/pages/index.tsx",
+      startLine: 1,
+      endLine: 8,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({
+      path: "virtualis-terminal/pages/index.tsx",
+      startLine: 1,
+      endLine: 8,
+      truncated: true,
+    });
+    expect(result.message).toContain("virtualis-terminal/pages/index.tsx:1-8");
+    expect(result.message).toContain("import");
+  });
+
+  it("searches readable tracked files with literal queries", async () => {
+    const reader = new SelfRepoReader();
+
+    const result = await reader.search({
+      query: "MobileDenial",
+      pathPrefix: "virtualis-terminal/components",
+      limit: 5,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({
+      truncated: expect.any(Boolean),
+    });
+    expect(result.message).toContain("MobileDenial");
+    expect(result.message).toContain("virtualis-terminal/components");
+  });
+
+  it("rejects traversal and denied runtime files", async () => {
+    const reader = new SelfRepoReader();
+
+    await expect(
+      reader.readFile({ path: "../virtualis-terminal/package.json" }),
+    ).rejects.toThrow("Repository path must be relative");
+
+    await expect(
+      reader.readFile({ path: "virtualis-terminal/.env.example" }),
+    ).rejects.toThrow("Path is not a readable tracked file");
+  });
+});

--- a/virtualis-terminal/tests/unit/chat/claudeToolDispatch.test.ts
+++ b/virtualis-terminal/tests/unit/chat/claudeToolDispatch.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { dispatchClaudeToolUse } from "@/lib/chat/claudeToolDispatch";
-import type {
-  HardCommandOperations,
-  HardCommandResponse,
-} from "@/lib/chat/hardCommands";
+import {
+  dispatchClaudeToolUse,
+  type ClaudeToolOperations,
+} from "@/lib/chat/claudeToolDispatch";
+import type { HardCommandResponse } from "@/lib/chat/hardCommands";
 import type { ToolUseBlock } from "@/lib/chat/messageCodec";
 import { DocumentType, ProjectSubType, OtherSubType } from "@/types/documents";
 
@@ -23,7 +23,7 @@ function ok(message = "ok"): Promise<HardCommandResponse> {
   return Promise.resolve({ success: true, message });
 }
 
-function operations(): HardCommandOperations {
+function operations(): ClaudeToolOperations {
   return {
     runDocIdCommand: vi.fn(() => ok()),
     runDocsCommand: vi.fn(() => ok()),
@@ -32,6 +32,10 @@ function operations(): HardCommandOperations {
     runSearchCommand: vi.fn(() => ok()),
     runOtherCommand: vi.fn(() => ok()),
     runStatusCommand: vi.fn(() => ok()),
+    runSelfRepoCurrentCommit: vi.fn(() => ok()),
+    runSelfRepoList: vi.fn(() => ok()),
+    runSelfRepoReadFile: vi.fn(() => ok()),
+    runSelfRepoSearch: vi.fn(() => ok()),
   };
 }
 
@@ -103,6 +107,43 @@ describe("dispatchClaudeToolUse", () => {
     await expect(
       dispatchClaudeToolUse(toolUse("unknown_tool"), operations()),
     ).resolves.toBeNull();
+  });
+
+  it("dispatches self repository file reads with line bounds", async () => {
+    const commandOperations = operations();
+
+    await dispatchClaudeToolUse(
+      toolUse("self_repo_read_file", {
+        path: "virtualis-terminal/pages/index.tsx",
+        start_line: 1,
+        end_line: 20,
+      }),
+      commandOperations,
+    );
+
+    expect(commandOperations.runSelfRepoReadFile).toHaveBeenCalledWith({
+      path: "virtualis-terminal/pages/index.tsx",
+      startLine: 1,
+      endLine: 20,
+    });
+  });
+
+  it("dispatches self repository searches without shell command text", async () => {
+    const commandOperations = operations();
+
+    await dispatchClaudeToolUse(
+      toolUse("self_repo_search", {
+        query: "MobileDenial",
+        path_prefix: "virtualis-terminal/components",
+      }),
+      commandOperations,
+    );
+
+    expect(commandOperations.runSelfRepoSearch).toHaveBeenCalledWith({
+      query: "MobileDenial",
+      pathPrefix: "virtualis-terminal/components",
+      limit: undefined,
+    });
   });
 
   it("rejects invalid Claude tool input before command execution", async () => {

--- a/virtualis-terminal/tests/unit/chat/messageCodec.test.ts
+++ b/virtualis-terminal/tests/unit/chat/messageCodec.test.ts
@@ -3,6 +3,7 @@ import {
   decodeContentBlocks,
   fixContentBlocks,
   isPureToolResult,
+  normalizeToolResultAdjacency,
   parseAssistantReply,
   parseStoredMessage,
   type ThreadMessage,
@@ -48,5 +49,60 @@ describe("messageCodec", () => {
         timestamp: new Date("2026-05-03T00:00:00.000Z"),
       }),
     ).toThrow("Unsupported thread message role: system");
+  });
+
+  it("repairs tool result adjacency when timestamp ties reorder messages", () => {
+    const toolResult: ThreadMessage = {
+      role: "user",
+      timestamp: "2026-05-03T00:00:00.000Z",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "toolu_self",
+          content: '{"success":true}',
+        },
+      ],
+    };
+    const assistantToolUse: ThreadMessage = {
+      role: "assistant",
+      timestamp: "2026-05-03T00:00:00.000Z",
+      content: [
+        {
+          type: "tool_use",
+          id: "toolu_self",
+          name: "self_repo_list_files",
+          input: {},
+        },
+      ],
+    };
+
+    expect(
+      normalizeToolResultAdjacency([toolResult, assistantToolUse]).map(
+        (message) => message.role,
+      ),
+    ).toEqual(["assistant", "user"]);
+  });
+
+  it("drops dangling tool use blocks that cannot be paired", () => {
+    const messages = normalizeToolResultAdjacency([
+      {
+        role: "assistant",
+        timestamp: "2026-05-03T00:00:00.000Z",
+        content: [
+          { type: "text", text: "<reply>...processing...</reply>" },
+          {
+            type: "tool_use",
+            id: "toolu_missing",
+            name: "self_repo_list_files",
+            input: {},
+          },
+        ],
+      },
+    ]);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].content).toEqual([
+      { type: "text", text: "<reply>...processing...</reply>" },
+    ]);
   });
 });

--- a/virtualis-terminal/tests/unit/terminal/printUtils.test.ts
+++ b/virtualis-terminal/tests/unit/terminal/printUtils.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  TERMINAL_TEXT_COLUMNS,
+  wrapTerminalText,
+} from "@/components/Terminal/utils/printUtils";
+
+describe("wrapTerminalText", () => {
+  it("wraps prose on word boundaries before the CRT hard-wraps it", () => {
+    const lines = wrapTerminalText(
+      "The system is also, in a certain sense, self-aware - my own documentation lives in the vector store, making Cogitatio Virtualis itself a portfolio piece that can be queried, inspected, and reasoned about.",
+      48,
+    );
+
+    expect(lines).toEqual([
+      "The system is also, in a certain sense,",
+      "self-aware - my own documentation lives in the",
+      "vector store, making Cogitatio Virtualis itself",
+      "a portfolio piece that can be queried,",
+      "inspected, and reasoned about.",
+    ]);
+    expect(lines.every((line) => line.length <= 48)).toBe(true);
+  });
+
+  it("preserves explicit blank lines and wraps each paragraph independently", () => {
+    const lines = wrapTerminalText(
+      "first paragraph has some words\n\nsecond",
+      20,
+    );
+
+    expect(lines).toEqual([
+      "first paragraph has",
+      "some words",
+      "\u00A0",
+      "second",
+    ]);
+  });
+
+  it("indents bullet continuations under their original marker", () => {
+    const lines = wrapTerminalText(
+      "- first item contains enough words to require a continuation line",
+      32,
+    );
+
+    expect(lines).toEqual([
+      "- first item contains enough",
+      "  words to require a",
+      "  continuation line",
+    ]);
+  });
+
+  it("keeps default wrapped output inside the CRT text column budget", () => {
+    const lines = wrapTerminalText("alpha beta gamma ".repeat(20));
+
+    expect(lines.every((line) => line.length <= TERMINAL_TEXT_COLUMNS)).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## What
Adds read-only self-repository tools to Cogitatio Virtualis and tightens the terminal presentation so generated output remains readable during long responses.

## Why
Cogitatio should be able to answer implementation questions about its own tracked source without live filesystem access, and the CRT surface should not split prose mid-word or drag users away from scrollback while the assistant is still printing.

## Changes
- Added self-repository read tools
- Registered typed Claude dispatch handlers
- Repaired tool-result transcript ordering
- Wrapped terminal prose before CRT rendering
- Preserved scrollback during streaming output
- Covered wrapping and sticky scroll behavior

## Testing
- `npm run check`
- Manual local testing at `http://localhost:4000`
