### PR TITLE
chore: Add production CD path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,33 @@ jobs:
 
       - name: Build backend package
         run: python -m build
+
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs:
+      - frontend
+      - backend
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    environment: production
+    concurrency:
+      group: production
+      cancel-in-progress: false
+    steps:
+      - name: Prepare SSH key
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "${{ secrets.LIGHTSAIL_SSH_KEY }}" > ~/.ssh/lightsail_cd
+          chmod 600 ~/.ssh/lightsail_cd
+          printf '%s\n' "${{ secrets.LIGHTSAIL_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+
+      - name: Deploy production
+        env:
+          LIGHTSAIL_HOST: ${{ secrets.LIGHTSAIL_HOST }}
+          LIGHTSAIL_USER: ${{ secrets.LIGHTSAIL_USER }}
+          GIT_SHA: ${{ github.sha }}
+        run: |
+          ssh -i ~/.ssh/lightsail_cd \
+            -o IdentitiesOnly=yes \
+            "$LIGHTSAIL_USER@$LIGHTSAIL_HOST" \
+            "set -e; cd /home/ubuntu/cogitatio-virtualis && git fetch origin master && git checkout master && git pull --ff-only origin master && bash admin/deploy-production.sh $GIT_SHA"

--- a/.gitignore
+++ b/.gitignore
@@ -188,5 +188,7 @@ ipython_config.py
 firstconversation.md
 
 # Admin folder - local deployment configs, secrets, etc.
-/admin/
+/admin/*
+!/admin/deploy-production.sh
+!/admin/lightsail.md
 .worktrees/

--- a/admin/deploy-production.sh
+++ b/admin/deploy-production.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+APP_DIR="${APP_DIR:-/home/ubuntu/cogitatio-virtualis}"
+FRONTEND_DIR="$APP_DIR/virtualis-terminal"
+BACKEND_DIR="$APP_DIR/cogitatio-server"
+NODE_ENV_PATH="${NODE_ENV_PATH:-/home/ubuntu/miniconda3/envs/cv_env/bin}"
+PYTHON_BIN="${PYTHON_BIN:-/home/ubuntu/miniconda3/envs/cv_py312/bin/python}"
+TARGET_SHA="${1:-}"
+
+export PATH="$NODE_ENV_PATH:$PATH"
+
+log() {
+  printf '[deploy] %s\n' "$*"
+}
+
+contains_path() {
+  local path_prefix="$1"
+  grep -qE "^${path_prefix}" <<<"$CHANGED_FILES"
+}
+
+log "starting production deployment"
+cd "$APP_DIR"
+
+PREVIOUS_SHA="$(git rev-parse HEAD)"
+log "current checkout: $PREVIOUS_SHA"
+
+git fetch origin master
+git checkout master
+git pull --ff-only origin master
+
+CURRENT_SHA="$(git rev-parse HEAD)"
+log "updated checkout: $CURRENT_SHA"
+
+if [[ -n "$TARGET_SHA" && "$CURRENT_SHA" != "$TARGET_SHA" ]]; then
+  log "expected $TARGET_SHA but checked out $CURRENT_SHA"
+  exit 1
+fi
+
+if [[ "$PREVIOUS_SHA" == "$CURRENT_SHA" ]]; then
+  CHANGED_FILES=""
+else
+  CHANGED_FILES="$(git diff --name-only "$PREVIOUS_SHA" "$CURRENT_SHA")"
+fi
+
+if [[ -z "$CHANGED_FILES" ]]; then
+  log "no new files changed; verifying frontend process"
+  pm2 restart cogitatio-virtualis
+  exit 0
+fi
+
+log "changed files:"
+printf '%s\n' "$CHANGED_FILES"
+
+if contains_path "cogitatio-server/"; then
+  log "installing backend package"
+  cd "$BACKEND_DIR"
+  "$PYTHON_BIN" -m pip install -e .
+
+  log "restarting cogitatio.service"
+  sudo systemctl restart cogitatio.service
+fi
+
+if contains_path "virtualis-terminal/" || contains_path "package-lock.json" || contains_path ".node-version"; then
+  log "installing frontend dependencies"
+  cd "$FRONTEND_DIR"
+  npm ci
+
+  log "building frontend"
+  npm run build
+
+  log "restarting frontend process"
+  pm2 restart cogitatio-virtualis
+fi
+
+log "deployment complete"

--- a/admin/lightsail.md
+++ b/admin/lightsail.md
@@ -1,0 +1,60 @@
+# AWS Lightsail Production Instance
+
+## Connection Details
+
+- **Host:** 54.187.114.114
+- **User:** ubuntu
+- **SSH Key:** ~/.ssh/talwet
+
+## Quick Connect
+
+```bash
+ssh -i ~/.ssh/talwet ubuntu@54.187.114.114
+```
+
+## SCP Examples
+
+```bash
+# Copy file TO server
+scp -i ~/.ssh/talwet /local/path ubuntu@54.187.114.114:~/remote/path
+
+# Copy file FROM server
+scp -i ~/.ssh/talwet ubuntu@54.187.114.114:~/remote/path /local/path
+
+# Copy directory recursively
+scp -i ~/.ssh/talwet -r ubuntu@54.187.114.114:~/remote/dir /local/dir
+```
+
+## Server Layout
+
+- **Home:** /home/ubuntu/
+- **App:** /home/ubuntu/cogitatio-virtualis/
+  - cogitatio-server/ (backend)
+  - virtualis-terminal/ (frontend)
+- **Process Manager:** PM2
+
+## Notes
+
+- This is the production deployment of Cogitatio Virtualis
+- Documents for vector DB: cogitatio-server/documents/
+- Resume PDF: virtualis-terminal/public/resume.pdf
+
+## Continuous Deployment
+
+Production deploys are handled by GitHub Actions after CI passes on `master`.
+The `Deploy` job connects over SSH and runs:
+
+```bash
+/home/ubuntu/cogitatio-virtualis/admin/deploy-production.sh <merge-sha>
+```
+
+The workflow requires these repository secrets:
+
+- `LIGHTSAIL_HOST`
+- `LIGHTSAIL_USER`
+- `LIGHTSAIL_SSH_KEY`
+- `LIGHTSAIL_KNOWN_HOSTS`
+
+The deploy script fast-forwards the production checkout, installs and restarts
+the backend when `cogitatio-server/` changes, and installs/builds/restarts the
+frontend when `virtualis-terminal/` changes.

--- a/virtualis-terminal/components/Terminal/VirtualisTerminal.tsx
+++ b/virtualis-terminal/components/Terminal/VirtualisTerminal.tsx
@@ -30,7 +30,7 @@ import {
 import { RestoredTranscript } from "./RestoredTranscript";
 import { ASCII_ERROR_LINES } from "./config/ascii.config";
 import { DeepPartial } from "@/components/Terminal/utils/deepMerge";
-import { stripTrailingLoaderFrame } from "@/components/Terminal/utils/commandSanitizer";
+import { stripLeakedLoaderFrame } from "@/components/Terminal/utils/commandSanitizer";
 import type { ThreadMessage } from "@/lib/chat/messageCodec";
 
 export interface VirtualisTerminalProps {
@@ -389,7 +389,7 @@ export const VirtualisTerminal: React.FC<VirtualisTerminalProps> = ({
       if (terminalState.mode !== "NORMAL" || !controller?.handleCommand) return;
 
       try {
-        const sanitizedCommand = stripTrailingLoaderFrame(
+        const sanitizedCommand = stripLeakedLoaderFrame(
           command,
           config.loader.slides,
         );

--- a/virtualis-terminal/components/Terminal/utils/commandSanitizer.ts
+++ b/virtualis-terminal/components/Terminal/utils/commandSanitizer.ts
@@ -1,7 +1,7 @@
 /**
- * Removes a leaked crt-terminal loader frame from the end of a submitted command.
+ * Removes leaked crt-terminal loader frames from a submitted command.
  */
-export function stripTrailingLoaderFrame(
+export function stripLeakedLoaderFrame(
   command: string,
   loaderFrames: readonly string[],
 ): string {
@@ -13,17 +13,27 @@ export function stripTrailingLoaderFrame(
   const frames = [...new Set(loaderFrames.filter(Boolean))].sort(
     (a, b) => b.length - a.length,
   );
-  const leakedFrame = frames.find(
-    (frame) => trimmedCommand.endsWith(frame) && trimmedCommand !== frame,
+  const leadingFrame = frames.find(
+    (frame) => trimmedCommand.startsWith(frame) && trimmedCommand !== frame,
   );
+  const withoutLeadingFrame = leadingFrame
+    ? trimmedCommand.slice(leadingFrame.length).trimStart()
+    : trimmedCommand;
 
-  if (!leakedFrame) {
-    return trimmedCommand;
-  }
+  const trailingFrame = frames.find(
+    (frame) =>
+      withoutLeadingFrame.endsWith(frame) && withoutLeadingFrame !== frame,
+  );
+  const withoutTrailingFrame = trailingFrame
+    ? withoutLeadingFrame.slice(0, -trailingFrame.length).trimEnd()
+    : withoutLeadingFrame;
 
-  const commandWithoutFrame = trimmedCommand
-    .slice(0, -leakedFrame.length)
-    .trimEnd();
+  return withoutTrailingFrame || trimmedCommand;
+}
 
-  return commandWithoutFrame || trimmedCommand;
+export function stripTrailingLoaderFrame(
+  command: string,
+  loaderFrames: readonly string[],
+): string {
+  return stripLeakedLoaderFrame(command, loaderFrames);
 }

--- a/virtualis-terminal/tests/unit/terminal/commandSanitizer.test.ts
+++ b/virtualis-terminal/tests/unit/terminal/commandSanitizer.test.ts
@@ -1,19 +1,36 @@
 import { describe, expect, it } from "vitest";
 import { LOADING_FRAMES } from "@/components/Terminal/styles/terminal.styles";
-import { stripTrailingLoaderFrame } from "@/components/Terminal/utils/commandSanitizer";
+import {
+  stripLeakedLoaderFrame,
+  stripTrailingLoaderFrame,
+} from "@/components/Terminal/utils/commandSanitizer";
 
-describe("stripTrailingLoaderFrame", () => {
+describe("stripLeakedLoaderFrame", () => {
   it("removes a leaked configured loader frame from command input", () => {
-    expect(stripTrailingLoaderFrame("/status⠼", LOADING_FRAMES)).toBe(
-      "/status",
+    expect(stripLeakedLoaderFrame("/status⠼", LOADING_FRAMES)).toBe("/status");
+  });
+
+  it("removes a leaked leading loader frame from command input", () => {
+    expect(stripLeakedLoaderFrame("⠼please think slowly", LOADING_FRAMES)).toBe(
+      "please think slowly",
     );
   });
 
+  it("removes leaked leading and trailing loader frames from command input", () => {
+    expect(stripLeakedLoaderFrame("⠼/status⠼", LOADING_FRAMES)).toBe("/status");
+  });
+
   it("preserves normal command input", () => {
-    expect(stripTrailingLoaderFrame("/status", LOADING_FRAMES)).toBe("/status");
+    expect(stripLeakedLoaderFrame("/status", LOADING_FRAMES)).toBe("/status");
   });
 
   it("does not turn a standalone loader frame into an empty command", () => {
-    expect(stripTrailingLoaderFrame("⠼", LOADING_FRAMES)).toBe("⠼");
+    expect(stripLeakedLoaderFrame("⠼", LOADING_FRAMES)).toBe("⠼");
+  });
+
+  it("keeps the previous trailing-frame helper as a compatibility alias", () => {
+    expect(stripTrailingLoaderFrame("/status⠼", LOADING_FRAMES)).toBe(
+      "/status",
+    );
   });
 });


### PR DESCRIPTION
## What
Adds a production CD path for the Lightsail-hosted Cogitatio Virtualis stack.

## Why
Deploys have been manual: pull master on the instance, build the frontend, and restart PM2. This makes that path repeatable and gated behind the existing frontend and backend CI checks.

## Changes
- Added gated deploy job
- Added Lightsail deploy script
- Documented production secrets
- Tracked admin deploy files
- Added dedicated deploy SSH key

## Testing
- `bash -n admin/deploy-production.sh`
- Workflow YAML parsed locally
- Frontend: `npm run check`
- Backend: `python -m pytest cogitatio/tests -q && python -m compileall -q cogitatio scripts && python -m build`
- Smoke-tested deploy script against current production checkout
