### PR TITLE
fix: Preserve deploy diff during CD bootstrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,4 +104,4 @@ jobs:
           ssh -i ~/.ssh/lightsail_cd \
             -o IdentitiesOnly=yes \
             "$LIGHTSAIL_USER@$LIGHTSAIL_HOST" \
-            "set -e; cd /home/ubuntu/cogitatio-virtualis && git fetch origin master && git checkout master && git pull --ff-only origin master && bash admin/deploy-production.sh $GIT_SHA"
+            "set -e; cd /home/ubuntu/cogitatio-virtualis && if [ ! -x admin/deploy-production.sh ]; then git fetch origin master && git checkout master && git pull --ff-only origin master; fi && bash admin/deploy-production.sh $GIT_SHA"


### PR DESCRIPTION
## What
Fixes the CD workflow bootstrap wrapper so deployment diffing remains accurate.

## Why
The first deploy run fast-forwarded the production checkout before invoking the deploy script, which meant the script saw no changed files. Future runs should let the script own pull and changed-file detection unless the script is missing on the server.

## Changes
- Guarded bootstrap pull
- Preserved deploy-script diffing
- Kept missing-script recovery path

## Testing
- Workflow YAML parsed locally
- Manually rebuilt/restarted production after identifying the bootstrap issue
- Smoke-tested production home and chat threads endpoints
