### PR TITLE
feat: Beautify the terminal screen to match the room scene

### DIFF
--- a/virtualis-terminal/components/MobileDenial/MobileDenial.module.css
+++ b/virtualis-terminal/components/MobileDenial/MobileDenial.module.css
@@ -59,8 +59,8 @@
   flex-direction: column;
   gap: 24px;
   text-shadow:
-    0 0 6px rgba(0, 255, 0, 0.42),
-    0 0 18px rgba(0, 255, 0, 0.18);
+    0 0 6px rgba(65, 255, 110, 0.42),
+    0 0 18px rgba(65, 255, 110, 0.18);
 }
 
 .logoFrame {

--- a/virtualis-terminal/components/RoomScene/CrtScreenEffects.tsx
+++ b/virtualis-terminal/components/RoomScene/CrtScreenEffects.tsx
@@ -27,6 +27,11 @@ export function CrtScreenEffects({ carColor }: CrtScreenEffectsProps) {
       <div className="tk-screen-glare" aria-hidden="true" />
       <div className="tk-screen-flicker" aria-hidden="true" />
       <div className="tk-screen-breathe" aria-hidden="true" />
+      <div className="tk-screen-poweron" aria-hidden="true">
+        <div className="tk-poweron-shutters" />
+        <div className="tk-poweron-line" />
+        <div className="tk-poweron-bloom" />
+      </div>
     </>
   );
 }

--- a/virtualis-terminal/components/RoomScene/RoomScene.css
+++ b/virtualis-terminal/components/RoomScene/RoomScene.css
@@ -634,6 +634,20 @@
   position: absolute;
   inset: 0;
   z-index: 1;
+  animation: tk-tube-warm 2.1s ease-out both;
+}
+
+/* Opacity-only warm-up keeps the power-on compositor-friendly. */
+@keyframes tk-tube-warm {
+  0% {
+    opacity: 0;
+  }
+  45% {
+    opacity: 0.25;
+  }
+  100% {
+    opacity: 1;
+  }
 }
 
 .tk-glass-window-reflect,
@@ -831,6 +845,117 @@
   }
 }
 
+/* One-shot tube power-on: black shutters part around a blooming scan line.
+   Base states are invisible so the overlay is inert when animations are off. */
+.tk-screen-poweron {
+  position: absolute;
+  inset: 0;
+  z-index: 12;
+  pointer-events: none;
+}
+
+.tk-poweron-shutters,
+.tk-poweron-line,
+.tk-poweron-bloom {
+  position: absolute;
+  inset: 0;
+}
+
+.tk-poweron-shutters::before,
+.tk-poweron-shutters::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  left: 0;
+  height: 51%;
+  background: #010302;
+  transform: scaleY(0);
+  animation: tk-poweron-shutter 1.5s cubic-bezier(0.7, 0, 0.3, 1) both;
+}
+
+.tk-poweron-shutters::before {
+  top: 0;
+  transform-origin: center top;
+}
+
+.tk-poweron-shutters::after {
+  bottom: 0;
+  transform-origin: center bottom;
+}
+
+@keyframes tk-poweron-shutter {
+  0%,
+  42% {
+    transform: scaleY(1);
+  }
+  100% {
+    transform: scaleY(0);
+  }
+}
+
+.tk-poweron-line {
+  opacity: 0;
+  background: linear-gradient(
+    180deg,
+    transparent calc(50% - 8px),
+    rgba(65, 255, 110, 0.12) calc(50% - 3px),
+    rgba(214, 255, 226, 0.9) calc(50% - 1px),
+    #f4fff7 50%,
+    rgba(214, 255, 226, 0.9) calc(50% + 1px),
+    rgba(65, 255, 110, 0.12) calc(50% + 3px),
+    transparent calc(50% + 8px)
+  );
+  mix-blend-mode: screen;
+  animation: tk-poweron-line 1.5s ease-out both;
+}
+
+@keyframes tk-poweron-line {
+  0% {
+    opacity: 0;
+    transform: scaleX(0.02);
+  }
+  16% {
+    opacity: 1;
+    transform: scaleX(0.07);
+  }
+  40% {
+    opacity: 1;
+    transform: scaleX(1);
+  }
+  62% {
+    opacity: 0.5;
+  }
+  100% {
+    opacity: 0;
+    transform: scaleX(1);
+  }
+}
+
+.tk-poweron-bloom {
+  opacity: 0;
+  background: radial-gradient(
+    ellipse at 50% 50%,
+    rgba(120, 255, 150, 0.4) 0%,
+    rgba(57, 255, 90, 0.1) 55%,
+    transparent 80%
+  );
+  mix-blend-mode: screen;
+  animation: tk-poweron-bloom 2.1s ease-out both;
+}
+
+@keyframes tk-poweron-bloom {
+  0%,
+  40% {
+    opacity: 0;
+  }
+  62% {
+    opacity: 0.85;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
 .tk-underglow {
   position: relative;
   z-index: 0;
@@ -989,7 +1114,8 @@
   .tk-carpass,
   .tk-ped,
   .tk-motes,
-  .tk-screen-moving-scanner {
+  .tk-screen-moving-scanner,
+  .tk-screen-poweron {
     display: none !important;
   }
 }

--- a/virtualis-terminal/components/Terminal/VirtualisTerminal.tsx
+++ b/virtualis-terminal/components/Terminal/VirtualisTerminal.tsx
@@ -107,6 +107,7 @@ export const VirtualisTerminal: React.FC<VirtualisTerminalProps> = ({
   );
   const performRecoveryRef = useRef(async (): Promise<void> => {});
   const controllerRef = useRef<Controller | null>(null);
+  const pendingCommandsRef = useRef<string[]>([]);
   const clearTerminalRef = useRef(async (): Promise<void> => {});
   const surfaceRef = useRef<HTMLDivElement>(null);
   const shouldAutoScrollRef = useRef(true);
@@ -233,6 +234,13 @@ export const VirtualisTerminal: React.FC<VirtualisTerminalProps> = ({
 
         await newController.mount(terminalHandle);
         setController(newController);
+
+        if (newController.handleCommand) {
+          const queuedCommands = pendingCommandsRef.current.splice(0);
+          for (const queuedCommand of queuedCommands) {
+            await newController.handleCommand(queuedCommand);
+          }
+        }
       } catch (error) {
         console.error(`[VirtualisTerminal] Mount error:`, error);
         await handleErrorRef.current(error as Error);
@@ -386,13 +394,21 @@ export const VirtualisTerminal: React.FC<VirtualisTerminalProps> = ({
 
   const handleCommand = useCallback(
     async (command: string) => {
-      if (terminalState.mode !== "NORMAL" || !controller?.handleCommand) return;
+      if (terminalState.mode !== "NORMAL") return;
+
+      const sanitizedCommand = stripLeakedLoaderFrame(
+        command,
+        config.loader.slides,
+      );
+
+      // Commands can arrive before the designated controller finishes
+      // mounting; hold them so they run once it does instead of vanishing.
+      if (!controller?.handleCommand) {
+        pendingCommandsRef.current.push(sanitizedCommand);
+        return;
+      }
 
       try {
-        const sanitizedCommand = stripLeakedLoaderFrame(
-          command,
-          config.loader.slides,
-        );
         await controller.handleCommand(sanitizedCommand);
       } catch (error) {
         await handleError(error as Error);
@@ -689,6 +705,7 @@ export const VirtualisTerminal: React.FC<VirtualisTerminalProps> = ({
           position: absolute;
           inset: 0;
           overflow: hidden;
+          container-type: inline-size;
           background: ${config.theme.background};
         }
 
@@ -699,19 +716,51 @@ export const VirtualisTerminal: React.FC<VirtualisTerminalProps> = ({
           padding: 0.65rem 0.45rem;
           border: 0;
           border-radius: 0;
+          color: var(--terminal-green);
+          line-height: 1.45;
+          text-shadow: var(--crt-fringe), var(--crt-bloom);
           background: radial-gradient(
             80% 80% at 50% 50%,
-            #102210 0%,
-            #061006 58%,
-            #020602 100%
+            #0f2412 0%,
+            #07120a 58%,
+            #030704 100%
           );
           box-shadow: none;
+        }
+
+        :global(.terminal-surface ::selection) {
+          background: rgba(65, 255, 110, 0.85);
+          color: #052b12;
+          text-shadow: none;
         }
 
         :global(.terminal-surface .crt-terminal__overflow-container) {
           height: 100%;
           max-height: 100%;
           border-radius: 0;
+          scrollbar-width: thin;
+          scrollbar-color: rgba(65, 255, 110, 0.3) transparent;
+        }
+
+        :global(
+          .terminal-surface .crt-terminal__overflow-container::-webkit-scrollbar
+        ) {
+          width: 6px;
+        }
+
+        :global(
+          .terminal-surface
+            .crt-terminal__overflow-container::-webkit-scrollbar-thumb
+        ) {
+          background: rgba(65, 255, 110, 0.28);
+          border-radius: 3px;
+        }
+
+        :global(
+          .terminal-surface
+            .crt-terminal__overflow-container::-webkit-scrollbar-track
+        ) {
+          background: transparent;
         }
 
         :global(.terminal-surface .crt-terminal__screen) {
@@ -740,6 +789,18 @@ export const VirtualisTerminal: React.FC<VirtualisTerminalProps> = ({
           overflow-wrap: anywhere;
           white-space: normal;
           word-break: break-word;
+        }
+
+        :global(.terminal-surface .crt-command-line__prompt),
+        :global(.terminal-surface .crt-command-line__input),
+        :global(.terminal-surface .crt-command-line__input-string),
+        :global(.terminal-surface .crt-cursor-symbol) {
+          color: var(--terminal-green-bright);
+        }
+
+        :global(.terminal-surface .ascii-line) {
+          font-size: clamp(7px, 1.7cqw, 14px);
+          white-space: pre;
         }
 
         :global(.terminal-surface .crt-restored-transcript) {

--- a/virtualis-terminal/components/Terminal/config/ascii.config.ts
+++ b/virtualis-terminal/components/Terminal/config/ascii.config.ts
@@ -93,7 +93,7 @@ export const ASCII_STYLES = `
     display: inline-block;
     opacity: 0;
     animation: asciiGlowChar 0.5s ease-out forwards;
-    text-shadow: 0 0 5px rgba(0, 255, 0, 0.5);
+    text-shadow: 0 0 5px rgba(65, 255, 110, 0.5);
   }
 
   @keyframes fadeInLine {

--- a/virtualis-terminal/components/Terminal/styles/asciiStyles.module.css
+++ b/virtualis-terminal/components/Terminal/styles/asciiStyles.module.css
@@ -2,7 +2,7 @@
 
 .ascii-container {
   position: relative;
-  color: #00ff00;
+  color: var(--terminal-green);
   white-space: pre;
   font-size: 12px;
   line-height: 1.2;
@@ -23,7 +23,7 @@
   }
   50% {
     opacity: 0.5;
-    text-shadow: 2px 2px 8px rgba(0, 255, 0, 0.5);
+    text-shadow: 2px 2px 8px rgba(65, 255, 110, 0.5);
   }
   100% {
     opacity: 1;
@@ -35,7 +35,7 @@
   display: inline-block;
   opacity: 0;
   animation: asciiGlowChar 0.5s ease-out forwards;
-  text-shadow: 0 0 5px rgba(0, 255, 0, 0.5);
+  text-shadow: 0 0 5px rgba(65, 255, 110, 0.5);
 }
 
 @keyframes asciiGlowChar {

--- a/virtualis-terminal/components/Terminal/styles/terminal.styles.ts
+++ b/virtualis-terminal/components/Terminal/styles/terminal.styles.ts
@@ -7,16 +7,16 @@ import {
 } from "../types/terminal";
 
 export const DEFAULT_THEME: TerminalTheme = {
-  background: "#0a0a0a",
-  foreground: "#00ff00",
-  primary: "#00ff00",
-  secondary: "#00cc00",
-  error: "#ff0000",
-  warning: "#ffff00",
-  success: "#00ff00",
-  system: "#00ffff",
-  dim: "rgba(0, 255, 0, 0.5)",
-  glow: "rgba(0, 255, 0, 0.2)",
+  background: "#040604",
+  foreground: "#41ff6e",
+  primary: "#41ff6e",
+  secondary: "#35e75f",
+  error: "#ff5555",
+  warning: "#ffd75e",
+  success: "#41ff6e",
+  system: "#5ee8e8",
+  dim: "rgba(65, 255, 110, 0.55)",
+  glow: "rgba(65, 255, 110, 0.2)",
   info: "",
   highlight: "",
 };
@@ -153,10 +153,10 @@ export const EFFECTS = {
   `,
 
   glow: `
-    box-shadow: 
-      0 0 10px rgba(0, 255, 0, 0.2),
-      0 0 20px rgba(0, 255, 0, 0.1),
-      0 0 30px rgba(0, 255, 0, 0.1);
+    box-shadow:
+      0 0 10px rgba(65, 255, 110, 0.2),
+      0 0 20px rgba(65, 255, 110, 0.1),
+      0 0 30px rgba(65, 255, 110, 0.1);
   `,
 
   flicker: `

--- a/virtualis-terminal/styles/globals.css
+++ b/virtualis-terminal/styles/globals.css
@@ -3,15 +3,21 @@
 /* Root Variables */
 :root {
   /* Core colors */
-  --background: #0a0a0a;
+  --background: #040604;
 
-  /* Terminal greens */
-  --terminal-green: #00ff00;
-  --terminal-green-dim: rgba(0, 255, 0, 0.5);
-  --terminal-green-faint: rgba(0, 255, 0, 0.1);
-  --terminal-green-bright: #00ff00;
-  --terminal-green-mid: #00cc00;
-  --terminal-green-dark: #009900;
+  /* Terminal greens — phosphor family shared with the room scene tube
+     (see --tk-phosphor in RoomScene.css) */
+  --terminal-green: #41ff6e;
+  --terminal-green-dim: rgba(65, 255, 110, 0.55);
+  --terminal-green-faint: rgba(65, 255, 110, 0.14);
+  --terminal-green-bright: #7bffa0;
+  --terminal-green-mid: #35e75f;
+  --terminal-green-dark: #23c248;
+
+  /* CRT text rendering: sub-pixel chromatic fringe + phosphor bloom */
+  --crt-fringe:
+    0.6px 0 rgba(255, 90, 70, 0.22), -0.6px 0 rgba(70, 150, 255, 0.18);
+  --crt-bloom: 0 0 6px rgba(65, 255, 110, 0.3);
 
   /* Error reds */
   --terminal-red: #ff5555;
@@ -81,7 +87,10 @@ body {
 }
 
 .message-assistant {
-  text-shadow: 0 0 8px var(--terminal-green-dark);
+  color: var(--terminal-green);
+  text-shadow:
+    var(--crt-fringe),
+    0 0 8px var(--terminal-green-faint);
 }
 
 /* Line Type Styles */
@@ -102,8 +111,11 @@ body {
 }
 
 .line-assistant {
-  color: var(--terminal-green-dark);
-  opacity: 0.85;
+  color: var(--terminal-green);
+  opacity: 0.92;
+  text-shadow:
+    var(--crt-fringe),
+    0 0 8px var(--terminal-green-faint);
 }
 
 /* Text Style Modifiers */
@@ -353,7 +365,7 @@ body {
   }
   100% {
     opacity: 1;
-    filter: blur(2px);
+    filter: blur(0.4px);
     color: var(--terminal-green-bright);
     text-shadow:
       0 0 7px var(--terminal-green-dim),


### PR DESCRIPTION
## Summary

The room scene facelift art-directed everything except the picture on the tube itself, which still ran the original styling: pure `#00ff00` web-green clashing with the room's curated `#39ff5a` phosphor, a boot logo that clipped off the right edge of the glass and carried a permanent 2px blur, default browser scrollbars inside a CRT, and a screen that simply appeared on page load. This pass makes the tube worthy of the room.

- **Unified phosphor palette** — the terminal now runs the room scene's phosphor family (`#41ff6e` core with tinted bright/mid/dim steps) across globals, the crt-terminal theme, the ascii art, and the mobile surface glow, so screen text, underglow, breathe, and toggle LEDs all read as one phosphor.
- **CRT power-on sequence** — on load, black shutters part around a blooming horizontal scan line while the picture warms up. Compositor-only (opacity/transform) and inert under `prefers-reduced-motion`.
- **Screen text rendering** — subtle sub-pixel chromatic fringe + phosphor bloom, brighter prompt/input/cursor, phosphor-on-dark text selection, thin themed scrollbar, and assistant replies raised from the dimmest green to the most readable step.
- **Boot logo fixes** — sized against the surface container (`cqw` clamp) so it can't clip, with the permanent blur reduced to a faint 0.4px softening.

## Bug fix surfaced by this work

Commands submitted before the active controller finished mounting were silently discarded — a fast-typing visitor's first question could vanish. The heavier power-on window made the restored-session e2e test catch this pre-existing race deterministically (command echoed, no POST ever fired). Early commands now queue and flush once the controller mounts.

## Verification

- prettier, eslint, `tsc --noEmit`
- vitest 32/32
- Full Playwright suite 11/11, run twice to confirm the race fix is stable
- Production `next build`
- Before/after/power-on screenshots reviewed at 1440×900

https://claude.ai/code/session_01KfCfdeCQw8yWZgvzof9o6R

---
_Generated by [Claude Code](https://claude.ai/code/session_01KfCfdeCQw8yWZgvzof9o6R)_