### PR TITLE
refactor: Deduplicate room scene ambience machinery

### DIFF
--- a/virtualis-terminal/components/RoomScene/CrtScreenEffects.tsx
+++ b/virtualis-terminal/components/RoomScene/CrtScreenEffects.tsx
@@ -1,25 +1,14 @@
-import type { CSSProperties } from "react";
-
-interface CrtScreenEffectsProps {
-  carColor?: string;
-}
-
 /**
  * Owns the complete CRT tube effect stack for the new monitor shell.
+ *
+ * Car-pass tinting flows in through the `--car-color` custom property set on
+ * the stage, so the stack needs no props.
  */
-export function CrtScreenEffects({ carColor }: CrtScreenEffectsProps) {
-  const style = carColor
-    ? ({ "--car-color": carColor } as CSSProperties)
-    : undefined;
-
+export function CrtScreenEffects() {
   return (
     <>
       <div className="tk-glass-window-reflect" aria-hidden="true" />
-      <div
-        className="tk-glass-headlight-reflect"
-        aria-hidden="true"
-        style={style}
-      />
+      <div className="tk-glass-headlight-reflect" aria-hidden="true" />
       <div className="tk-screen-static-scanlines" aria-hidden="true" />
       <div className="tk-screen-moving-scanner" aria-hidden="true" />
       <div className="tk-screen-noise" aria-hidden="true" />

--- a/virtualis-terminal/components/RoomScene/RoomScene.tsx
+++ b/virtualis-terminal/components/RoomScene/RoomScene.tsx
@@ -12,27 +12,34 @@ interface PedestrianSilhouetteProps {
   flip: boolean;
 }
 
-function actionFor(label: string): void {
-  switch (label) {
-    case "RESUME":
+const TOGGLES: { label: string; activate: () => void }[] = [
+  {
+    label: "RESUME",
+    activate: () => {
       window.open("/resume", "_blank", "popup,width=800,height=600");
-      break;
-    case "GITHUB":
+    },
+  },
+  {
+    label: "GITHUB",
+    activate: () => {
       window.open(
         "https://github.com/rabsef-bicrym/cogitatio-virtualis",
         "_blank",
         "noopener",
       );
-      break;
-    case "CONTACT":
+    },
+  },
+  {
+    label: "CONTACT",
+    activate: () => {
       window.location.href =
         "mailto:eric.helal@icloud.com?subject=" +
         encodeURIComponent(
           "Ref Cog.Vit: Hi Eric - Are you available for an interview?",
         );
-      break;
-  }
-}
+    },
+  },
+];
 
 function PedestrianSilhouette({ figNum, flip }: PedestrianSilhouetteProps) {
   const src = `/room/ped-${String(figNum).padStart(2, "0")}.png`;
@@ -45,19 +52,31 @@ function PedestrianSilhouette({ figNum, flip }: PedestrianSilhouetteProps) {
   );
 }
 
-function Toggle({ label }: { label: string }) {
+function Toggle({
+  label,
+  onActivate,
+}: {
+  label: string;
+  onActivate: () => void;
+}) {
   return (
-    <button
-      className="tk-toggle"
-      type="button"
-      onClick={() => actionFor(label)}
-    >
+    <button className="tk-toggle" type="button" onClick={onActivate}>
       <span className="tk-toggle-engraved">{label}</span>
       <span className="tk-toggle-body" aria-hidden="true">
         <span className="tk-toggle-lever" />
       </span>
       <span className="tk-toggle-led" aria-hidden="true" />
     </button>
+  );
+}
+
+function Vent() {
+  return (
+    <div className="tk-vent" aria-hidden="true">
+      {Array.from({ length: 22 }).map((_, index) => (
+        <span key={index} />
+      ))}
+    </div>
   );
 }
 
@@ -76,9 +95,7 @@ export function RoomScene({ children }: RoomSceneProps) {
 
   return (
     <section
-      className={`tk-stage tk-nocturne ${carEvent ? "tk-stage-pass" : ""} ${
-        pedEvent ? "tk-stage-ped" : ""
-      }`}
+      className={`tk-stage ${carEvent ? "tk-stage-pass" : ""}`}
       style={stageStyle}
       aria-label="Cogitatio Virtualis terminal room"
     >
@@ -93,12 +110,6 @@ export function RoomScene({ children }: RoomSceneProps) {
           <div
             key={carEvent.id}
             className={`tk-carpass tk-carpass-${carEvent.dir}`}
-            style={
-              {
-                "--car-color": carEvent.color,
-                "--car-speed": `${carEvent.speed}s`,
-              } as CSSProperties
-            }
           />
         ) : null}
         {pedEvent ? (
@@ -156,33 +167,19 @@ export function RoomScene({ children }: RoomSceneProps) {
         <div className="tk-highlight" aria-hidden="true" />
         <div className="tk-yellow" aria-hidden="true" />
         <div className="tk-monitor-litside" aria-hidden="true" />
-        <div
-          className="tk-monitor-headlight"
-          aria-hidden="true"
-          style={
-            carEvent ? ({ "--car-color": carEvent.color } as CSSProperties) : {}
-          }
-        />
+        <div className="tk-monitor-headlight" aria-hidden="true" />
         <div className="tk-dust tk-dust-tl" aria-hidden="true" />
         <div className="tk-dust tk-dust-tr" aria-hidden="true" />
 
         <div className="tk-row">
-          <div className="tk-vent" aria-hidden="true">
-            {Array.from({ length: 22 }).map((_, index) => (
-              <span key={index} />
-            ))}
-          </div>
+          <Vent />
           <div className="tk-glass">
             <div className="tk-glass-inner">
               <div className="tk-glass-content">{children}</div>
-              <CrtScreenEffects carColor={carEvent?.color} />
+              <CrtScreenEffects />
             </div>
           </div>
-          <div className="tk-vent" aria-hidden="true">
-            {Array.from({ length: 22 }).map((_, index) => (
-              <span key={index} />
-            ))}
-          </div>
+          <Vent />
         </div>
 
         <div className="tk-underglow" aria-hidden="true" />
@@ -195,9 +192,9 @@ export function RoomScene({ children }: RoomSceneProps) {
             </span>
           </div>
           <div className="tk-toggles">
-            <Toggle label="RESUME" />
-            <Toggle label="GITHUB" />
-            <Toggle label="CONTACT" />
+            {TOGGLES.map(({ label, activate }) => (
+              <Toggle key={label} label={label} onActivate={activate} />
+            ))}
           </div>
         </div>
       </div>

--- a/virtualis-terminal/components/RoomScene/useAmbientPasses.ts
+++ b/virtualis-terminal/components/RoomScene/useAmbientPasses.ts
@@ -32,7 +32,6 @@ export function useAmbientPasses<T extends AmbientPassEvent>({
 
   useEffect(() => {
     if (reducedMotion) {
-      setEvent(null);
       return;
     }
 
@@ -65,5 +64,7 @@ export function useAmbientPasses<T extends AmbientPassEvent>({
     };
   }, [reducedMotion, buildEvent, initialDelay, nextDelay, clearPaddingMs]);
 
-  return event;
+  // Derived at render time instead of cleared via setState in the effect,
+  // which would trigger a cascading render.
+  return reducedMotion ? null : event;
 }

--- a/virtualis-terminal/components/RoomScene/useAmbientPasses.ts
+++ b/virtualis-terminal/components/RoomScene/useAmbientPasses.ts
@@ -1,0 +1,69 @@
+import { useEffect, useState } from "react";
+import { useReducedMotion } from "./useReducedMotion";
+
+export interface AmbientPassEvent {
+  id: number;
+  speed: number;
+}
+
+export interface AmbientPassSchedule<T extends AmbientPassEvent> {
+  buildEvent: () => T;
+  initialDelay: () => number;
+  nextDelay: (event: T) => number;
+  /** Extra time the event stays mounted after its animation finishes. */
+  clearPaddingMs: number;
+}
+
+/**
+ * Shared scheduler for one-at-a-time ambient scene events: waits, fires the
+ * next event, clears it once its animation has played out, and repeats.
+ *
+ * The schedule callbacks must be stable references (module-level functions);
+ * they are effect dependencies, so a new identity restarts the scheduler.
+ */
+export function useAmbientPasses<T extends AmbientPassEvent>({
+  buildEvent,
+  initialDelay,
+  nextDelay,
+  clearPaddingMs,
+}: AmbientPassSchedule<T>): T | null {
+  const [event, setEvent] = useState<T | null>(null);
+  const reducedMotion = useReducedMotion();
+
+  useEffect(() => {
+    if (reducedMotion) {
+      setEvent(null);
+      return;
+    }
+
+    let cancelled = false;
+    let fireTimer: ReturnType<typeof setTimeout> | null = null;
+    let clearTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const schedule = (delay: number) => {
+      fireTimer = setTimeout(() => {
+        if (cancelled) return;
+
+        const nextEvent = buildEvent();
+        setEvent(nextEvent);
+        clearTimer = setTimeout(
+          () => {
+            setEvent(null);
+          },
+          nextEvent.speed * 1000 + clearPaddingMs,
+        );
+        schedule(nextDelay(nextEvent));
+      }, delay);
+    };
+
+    schedule(initialDelay());
+
+    return () => {
+      cancelled = true;
+      if (fireTimer) clearTimeout(fireTimer);
+      if (clearTimer) clearTimeout(clearTimer);
+    };
+  }, [reducedMotion, buildEvent, initialDelay, nextDelay, clearPaddingMs]);
+
+  return event;
+}

--- a/virtualis-terminal/components/RoomScene/useCarPasses.ts
+++ b/virtualis-terminal/components/RoomScene/useCarPasses.ts
@@ -1,5 +1,4 @@
-import { useEffect, useState } from "react";
-import { useReducedMotion } from "./useReducedMotion";
+import { useAmbientPasses } from "./useAmbientPasses";
 
 export type CarDirection = "ltr" | "rtl";
 
@@ -18,15 +17,6 @@ const CAR_COLORS = [
   "255, 200, 120",
 ];
 
-function nextCarDelay(speed: number): number {
-  const isDouble = Math.random() < 0.18;
-  if (isDouble) {
-    return speed * 1000 + 400 + Math.random() * 600;
-  }
-
-  return speed * 1000 + 30000 + Math.random() * 45000;
-}
-
 function buildCarEvent(): CarPassEvent {
   return {
     id: Date.now() + Math.random(),
@@ -36,55 +26,27 @@ function buildCarEvent(): CarPassEvent {
   };
 }
 
+function initialCarDelay(): number {
+  return 5000 + Math.random() * 20000;
+}
+
+function nextCarDelay(event: CarPassEvent): number {
+  const isDouble = Math.random() < 0.18;
+  if (isDouble) {
+    return event.speed * 1000 + 400 + Math.random() * 600;
+  }
+
+  return event.speed * 1000 + 30000 + Math.random() * 45000;
+}
+
 /**
  * Schedules one car-pass event at a time and clears it after animation.
  */
 export function useCarPasses(): CarPassEvent | null {
-  const [event, setEvent] = useState<CarPassEvent | null>(null);
-  const reducedMotion = useReducedMotion();
-
-  useEffect(() => {
-    if (reducedMotion) {
-      const resetTimer = setTimeout(() => {
-        setEvent(null);
-      }, 0);
-      return () => clearTimeout(resetTimer);
-    }
-
-    let cancelled = false;
-    let fireTimer: ReturnType<typeof setTimeout> | null = null;
-    let clearTimer: ReturnType<typeof setTimeout> | null = null;
-
-    const clearTimers = () => {
-      if (fireTimer) clearTimeout(fireTimer);
-      if (clearTimer) clearTimeout(clearTimer);
-      fireTimer = null;
-      clearTimer = null;
-    };
-
-    const schedule = (delay: number) => {
-      fireTimer = setTimeout(() => {
-        if (cancelled) return;
-
-        const nextEvent = buildCarEvent();
-        setEvent(nextEvent);
-        clearTimer = setTimeout(
-          () => {
-            setEvent(null);
-          },
-          nextEvent.speed * 1000 + 120,
-        );
-        schedule(nextCarDelay(nextEvent.speed));
-      }, delay);
-    };
-
-    schedule(5000 + Math.random() * 20000);
-
-    return () => {
-      cancelled = true;
-      clearTimers();
-    };
-  }, [reducedMotion]);
-
-  return event;
+  return useAmbientPasses({
+    buildEvent: buildCarEvent,
+    initialDelay: initialCarDelay,
+    nextDelay: nextCarDelay,
+    clearPaddingMs: 120,
+  });
 }

--- a/virtualis-terminal/components/RoomScene/usePedestrianPasses.ts
+++ b/virtualis-terminal/components/RoomScene/usePedestrianPasses.ts
@@ -1,6 +1,5 @@
-import { useEffect, useState } from "react";
 import { PED_FACING, type PedestrianFacing } from "./pedFacing";
-import { useReducedMotion } from "./useReducedMotion";
+import { useAmbientPasses } from "./useAmbientPasses";
 
 export type PedestrianDirection = "ltr" | "rtl";
 
@@ -49,55 +48,22 @@ function buildPedestrianEvent(): PedestrianPassEvent {
   };
 }
 
+function initialPedestrianDelay(): number {
+  return 10000 + Math.random() * 25000;
+}
+
+function nextPedestrianDelay(event: PedestrianPassEvent): number {
+  return event.speed * 1000 + 60000 + Math.random() * 180000;
+}
+
 /**
  * Schedules pedestrian silhouettes independently from car passes.
  */
 export function usePedestrianPasses(): PedestrianPassEvent | null {
-  const [event, setEvent] = useState<PedestrianPassEvent | null>(null);
-  const reducedMotion = useReducedMotion();
-
-  useEffect(() => {
-    if (reducedMotion) {
-      const resetTimer = setTimeout(() => {
-        setEvent(null);
-      }, 0);
-      return () => clearTimeout(resetTimer);
-    }
-
-    let cancelled = false;
-    let fireTimer: ReturnType<typeof setTimeout> | null = null;
-    let clearTimer: ReturnType<typeof setTimeout> | null = null;
-
-    const clearTimers = () => {
-      if (fireTimer) clearTimeout(fireTimer);
-      if (clearTimer) clearTimeout(clearTimer);
-      fireTimer = null;
-      clearTimer = null;
-    };
-
-    const schedule = (delay: number) => {
-      fireTimer = setTimeout(() => {
-        if (cancelled) return;
-
-        const nextEvent = buildPedestrianEvent();
-        setEvent(nextEvent);
-        clearTimer = setTimeout(
-          () => {
-            setEvent(null);
-          },
-          nextEvent.speed * 1000 + 160,
-        );
-        schedule(nextEvent.speed * 1000 + 60000 + Math.random() * 180000);
-      }, delay);
-    };
-
-    schedule(10000 + Math.random() * 25000);
-
-    return () => {
-      cancelled = true;
-      clearTimers();
-    };
-  }, [reducedMotion]);
-
-  return event;
+  return useAmbientPasses({
+    buildEvent: buildPedestrianEvent,
+    initialDelay: initialPedestrianDelay,
+    nextDelay: nextPedestrianDelay,
+    clearPaddingMs: 160,
+  });
 }


### PR DESCRIPTION
## Summary

Cleanup pass over the room-scene ambience work, no behavior change intended (net −17 lines with more of them being declarative):

- **Shared scheduler** — `useCarPasses` and `usePedestrianPasses` were ~80% identical (two-timer scheduling, cancellation flag, reduced-motion reset). That machinery now lives once in `useAmbientPasses`; each hook only declares its event builder and delay policy, so a third ambient event type (siren glow, a cat on the sill...) is a ~30-line file.
- **Dead classes** — `tk-nocturne` and `tk-stage-ped` were emitted but referenced by no stylesheet.
- **Data-driven toggles** — the bezel switches dispatched through a `switch` keyed on their *display label*; label and action now travel together in one `TOGGLES` table.
- **Vent dedupe** — the two identical vent columns collapse into a `Vent` component.
- **Redundant CSS vars** — the car pass, monitor headlight, and glass reflection each re-set `--car-color`/`--car-speed` inline with the exact values the stage already provides; custom properties inherit, so the inline styles are gone and `CrtScreenEffects` sheds its only prop.

## Verification

- prettier, eslint, `tsc --noEmit`, vitest 32/32, full Playwright suite 11/11, production build
- Forced a car pass deterministically via Playwright clock control and confirmed the tint/speed still resolve on `.tk-carpass` through inheritance (`--car-color: 210, 230, 255` observed on the element)

Independent of #12 — no overlapping hunks; the only shared file (`CrtScreenEffects.tsx`) is touched at opposite ends, so the branches merge cleanly in either order.

https://claude.ai/code/session_01KfCfdeCQw8yWZgvzof9o6R

---
_Generated by [Claude Code](https://claude.ai/code/session_01KfCfdeCQw8yWZgvzof9o6R)_