### PR TITLE
Noir light pass: sweeping headlight bars, swamped shadows, phosphor spill

### DIFF
--- a/virtualis-terminal/components/RoomScene/RoomScene.css
+++ b/virtualis-terminal/components/RoomScene/RoomScene.css
@@ -207,6 +207,27 @@
   );
 }
 
+/* The tube is the brightest thing in the room: phosphor halo on the wall
+   around the monitor, breathing with the screen. */
+.tk-screen-spill {
+  position: absolute;
+  top: 8%;
+  right: 4%;
+  bottom: 12%;
+  left: 4%;
+  z-index: 0;
+  background: radial-gradient(
+    58% 52% at 50% 52%,
+    rgba(57, 255, 90, 0.17) 0%,
+    rgba(57, 255, 90, 0.07) 45%,
+    transparent 72%
+  );
+  filter: blur(24px);
+  mix-blend-mode: screen;
+  opacity: 0.65;
+  animation: tk-breathe 6s ease-in-out infinite;
+}
+
 .tk-motes {
   position: absolute;
   inset: 0;
@@ -214,6 +235,19 @@
   overflow: hidden;
   pointer-events: none;
   mix-blend-mode: screen;
+  /* dust only reads where light catches it: confine to the streetlight shaft */
+  mask-image: radial-gradient(
+    72% 88% at 100% 30%,
+    #000 18%,
+    rgba(0, 0, 0, 0.3) 55%,
+    transparent 78%
+  );
+  -webkit-mask-image: radial-gradient(
+    72% 88% at 100% 30%,
+    #000 18%,
+    rgba(0, 0, 0, 0.3) 55%,
+    transparent 78%
+  );
 }
 
 .tk-motes span {
@@ -287,15 +321,15 @@
     opacity: 0;
   }
   25% {
-    opacity: 0.85;
+    opacity: 0.5;
   }
   50% {
     top: -25%;
     left: -15%;
-    opacity: 1;
+    opacity: 0.62;
   }
   75% {
-    opacity: 0.7;
+    opacity: 0.42;
   }
   100% {
     top: 0%;
@@ -311,15 +345,15 @@
     opacity: 0;
   }
   25% {
-    opacity: 0.85;
+    opacity: 0.5;
   }
   50% {
     top: -25%;
     left: -15%;
-    opacity: 1;
+    opacity: 0.62;
   }
   75% {
-    opacity: 0.7;
+    opacity: 0.42;
   }
   100% {
     top: -50%;
@@ -328,8 +362,127 @@
   }
 }
 
+/* The car's headlights project their own slat pattern: bright bars that
+   sweep across the wall while the streetlight's static shadows stay put.
+   Lives inside .tk-blinds-perspective so it inherits the same projection. */
+.tk-blinds-carlight {
+  position: absolute;
+  inset: -12%;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    179deg,
+    rgba(var(--car-color, 255, 245, 220), 0) 0,
+    rgba(var(--car-color, 255, 245, 220), 0.3) 4px,
+    rgba(var(--car-color, 255, 245, 220), 0.3) 10px,
+    rgba(var(--car-color, 255, 245, 220), 0) 14px,
+    rgba(var(--car-color, 255, 245, 220), 0) 28px
+  );
+  mask-image: radial-gradient(85% 85% at 100% 50%, #000 25%, transparent 80%);
+  -webkit-mask-image: radial-gradient(
+    85% 85% at 100% 50%,
+    #000 25%,
+    transparent 80%
+  );
+  mix-blend-mode: screen;
+  opacity: 0;
+  animation: var(--carlight-anim, tk-carlight-ltr) var(--car-speed, 3s)
+    cubic-bezier(0.45, 0.05, 0.55, 0.95) forwards;
+  will-change: transform, opacity;
+}
+
+.tk-blinds-carlight-ltr {
+  --carlight-anim: tk-carlight-ltr;
+}
+
+.tk-blinds-carlight-rtl {
+  --carlight-anim: tk-carlight-rtl;
+}
+
+@keyframes tk-carlight-ltr {
+  0% {
+    opacity: 0;
+    transform: rotate(-2deg) translate(-34px, 48px) skewY(3.5deg);
+  }
+  25% {
+    opacity: 0.5;
+  }
+  50% {
+    opacity: 0.68;
+    transform: rotate(-2deg) translate(0, -6px) skewY(0deg);
+  }
+  75% {
+    opacity: 0.38;
+  }
+  100% {
+    opacity: 0;
+    transform: rotate(-2deg) translate(34px, -60px) skewY(-3.5deg);
+  }
+}
+
+@keyframes tk-carlight-rtl {
+  0% {
+    opacity: 0;
+    transform: rotate(-2deg) translate(34px, -60px) skewY(-3.5deg);
+  }
+  25% {
+    opacity: 0.5;
+  }
+  50% {
+    opacity: 0.68;
+    transform: rotate(-2deg) translate(0, -6px) skewY(0deg);
+  }
+  75% {
+    opacity: 0.38;
+  }
+  100% {
+    opacity: 0;
+    transform: rotate(-2deg) translate(-34px, 48px) skewY(3.5deg);
+  }
+}
+
+/* A walker briefly blocks the streetlight mid-stride. Declared before the
+   car-pass rule so headlights win when both events overlap. */
+.tk-stage-walk .tk-streetlight {
+  animation: tk-streetlight-shadowed var(--ped-speed, 7s) ease-in-out forwards;
+}
+
+@keyframes tk-streetlight-shadowed {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  40%,
+  60% {
+    opacity: 0.82;
+  }
+}
+
 .tk-stage-pass .tk-streetlight {
   animation: tk-streetlight-dim var(--car-speed, 3s) ease-in-out forwards;
+}
+
+/* Headlights swamp the streetlight's pattern mid-pass: its shadows lose
+   contrast while the car's bars dominate, then snap back as the car exits. */
+.tk-stage-pass .tk-blinds {
+  animation: tk-blinds-recede var(--car-speed, 3s) ease-in-out forwards;
+}
+
+@keyframes tk-blinds-recede {
+  0% {
+    opacity: 0.55;
+  }
+  28% {
+    opacity: 0.14;
+  }
+  72% {
+    opacity: 0.12;
+  }
+  90% {
+    opacity: 0.48;
+  }
+  100% {
+    opacity: 0.55;
+  }
 }
 
 @keyframes tk-streetlight-dim {
@@ -442,6 +595,30 @@
   }
   50% {
     transform: translateY(-6px);
+  }
+}
+
+/* The streetlight-cast silhouette also washes out while headlights flood
+   the wall, mirroring tk-blinds-recede. */
+.tk-stage-pass .tk-ped-figure::before {
+  animation: tk-ped-swamped var(--car-speed, 3s) ease-in-out forwards;
+}
+
+@keyframes tk-ped-swamped {
+  0% {
+    opacity: 0.85;
+  }
+  28% {
+    opacity: 0.12;
+  }
+  72% {
+    opacity: 0.1;
+  }
+  90% {
+    opacity: 0.75;
+  }
+  100% {
+    opacity: 0.85;
   }
 }
 
@@ -990,6 +1167,12 @@
   .tk-ped,
   .tk-motes,
   .tk-screen-moving-scanner {
+    display: none !important;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tk-blinds-carlight {
     display: none !important;
   }
 }

--- a/virtualis-terminal/components/RoomScene/RoomScene.tsx
+++ b/virtualis-terminal/components/RoomScene/RoomScene.tsx
@@ -86,16 +86,29 @@ function Vent() {
 export function RoomScene({ children }: RoomSceneProps) {
   const carEvent = useCarPasses();
   const pedEvent = usePedestrianPasses();
-  const stageStyle = carEvent
-    ? ({
-        "--car-speed": `${carEvent.speed}s`,
-        "--car-color": carEvent.color,
-      } as CSSProperties)
-    : undefined;
+  const stageStyle =
+    carEvent || pedEvent
+      ? ({
+          ...(carEvent
+            ? {
+                "--car-speed": `${carEvent.speed}s`,
+                "--car-color": carEvent.color,
+              }
+            : {}),
+          ...(pedEvent
+            ? {
+                "--ped-speed": `${pedEvent.speed}s`,
+                "--ped-scale": pedEvent.scale,
+              }
+            : {}),
+        } as CSSProperties)
+      : undefined;
 
   return (
     <section
-      className={`tk-stage ${carEvent ? "tk-stage-pass" : ""}`}
+      className={`tk-stage ${carEvent ? "tk-stage-pass" : ""} ${
+        pedEvent ? "tk-stage-walk" : ""
+      }`}
       style={stageStyle}
       aria-label="Cogitatio Virtualis terminal room"
     >
@@ -104,6 +117,12 @@ export function RoomScene({ children }: RoomSceneProps) {
         <div className="tk-streetlight" />
         <div className="tk-blinds-perspective">
           <div className="tk-blinds" />
+          {carEvent ? (
+            <div
+              key={carEvent.id}
+              className={`tk-blinds-carlight tk-blinds-carlight-${carEvent.dir}`}
+            />
+          ) : null}
         </div>
         <div className="tk-floor" />
         {carEvent ? (
@@ -118,12 +137,6 @@ export function RoomScene({ children }: RoomSceneProps) {
             className={`tk-ped tk-ped-${pedEvent.dir} ${
               pedEvent.isCouple ? "tk-ped-couple" : ""
             }`}
-            style={
-              {
-                "--ped-speed": `${pedEvent.speed}s`,
-                "--ped-scale": pedEvent.scale,
-              } as CSSProperties
-            }
           >
             <PedestrianSilhouette
               figNum={pedEvent.figA}
@@ -137,6 +150,7 @@ export function RoomScene({ children }: RoomSceneProps) {
             ) : null}
           </div>
         ) : null}
+        <div className="tk-screen-spill" />
         <div className="tk-progressive-blur" aria-hidden="true">
           <div />
           <div />


### PR DESCRIPTION
Makes the room's light behave like light. Stacked on #13 (base branch) so the diff shows only this work; merges cleanly with #12 in either order.

## The car pass, refit

There are two light sources in this scene, so there are two slat projections — and they get treated separately:

- **The streetlight's shadows never move** (its source is fixed). Trying to animate the single existing blinds layer is what makes "the bars should sweep" feel impossible.
- **The car brings its own pattern**: a new `tk-blinds-carlight` element — bright bars in the headlight's color — mounted only during a pass, living *inside* `tk-blinds-perspective` so it inherits the same matrix3d projection and stripe geometry for free. One keyframe animation translates it ~3 slat periods while `skewY` eases +3.5° → 0° → −3.5° (the angle-of-incidence change as the car goes oblique → broadside → oblique). Direction-aware, compositor-only (transform/opacity), synced to `--car-speed`.
- **Perceptual dominance**: headlights swamp the ambient pattern, so `tk-blinds` recedes to ~0.13 opacity mid-pass and snaps back after the car exits (`tk-blinds-recede`) — the eye reads one dominant pattern shifting through, not two overlapping ones. Same treatment the streetlight glow already had.
- **Pedestrian coherence**: a silhouette is the streetlight's shadow, so the flood fills it in — figures fade to ~0.1 mid-pass and re-darken after (`tk-ped-swamped`). The first attempt left a 0.4 residual and the figure read *stronger* at peak flood (contrast follows background luminance); near-zero is both the physical and perceptual answer.
- The pass glow envelope is softened (peak 1.0 → 0.62) so peak flood stays warm night instead of blowing out to white.

## Ambient touches

- **Phosphor spill** (`tk-screen-spill`): the tube is the brightest thing in the room — it now throws a faint green halo on the wall around the monitor, breathing on the existing `tk-breathe` cycle. Gives the dead-black left half of the frame some form and finally lets the screen's green touch the room's amber.
- **Motes masked to the shaft**: dust only reads where light catches it; the mote field is now confined to the streetlight's beam.
- **Walker dims the streetlight**: a body crossing the light dips it briefly (`tk-streetlight-shadowed`), declared before the car rule so headlights win when events overlap. Pedestrian CSS vars moved up to the stage (inherit down), matching the car-pass pattern from #13.

## Reduced motion

New pass elements only mount when the schedulers run, which they don't under reduced motion; the carlight also gets an explicit `display: none` in its own `@media` block (kept separate from the existing list to avoid sharing a merge hunk with #12). The spill carries a static base opacity for when animations are off.

## Verification

- Forced car passes via injected events: bars sweep and skew across the wall, static pattern recedes/returns, no white-out at peak.
- Forced car+walker coincidence (rare in production — that's why it had to be right): silhouette washes to a ghost under the flood with bars raking across it, snaps back after.
- `npm run format` / `lint` / `tsc --noEmit` / `test:unit` (32) / `test:e2e` (11/11) / `build` all green. (One e2e run flaked on `preserves typed command text` — a braille loader frame leaking into the input under load; it pre-exists this branch and passes consistently otherwise.)

A dependent PR will follow from this branch adding the desk plane, with the blind-light terminating at the fold rather than painting across it.

https://claude.ai/code/session_01KfCfdeCQw8yWZgvzof9o6R

---
_Generated by [Claude Code](https://claude.ai/code/session_01KfCfdeCQw8yWZgvzof9o6R)_