### PR TITLE
Desk plane: the light stops at the fold

### DIFF
--- a/virtualis-terminal/components/RoomScene/RoomScene.css
+++ b/virtualis-terminal/components/RoomScene/RoomScene.css
@@ -69,11 +69,28 @@
   mix-blend-mode: screen;
 }
 
+/* The window light stops at the desk: stripes terminating at the fold is
+   itself the depth cue. The mask lives on this untransformed wrapper so the
+   cut is exactly horizontal (a mask inside the matrix3d would tilt), and it
+   clips the static slats and the sweeping car bars together. */
+.tk-window-light {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  mask-image: linear-gradient(180deg, #000 0%, #000 77.5%, transparent 81%);
+  -webkit-mask-image: linear-gradient(
+    180deg,
+    #000 0%,
+    #000 77.5%,
+    transparent 81%
+  );
+}
+
 .tk-blinds-perspective {
   position: absolute;
   inset: -10%;
   pointer-events: none;
-  z-index: 1;
   transform-origin: top right;
   transform-style: preserve-3d;
   transform: matrix3d(
@@ -205,6 +222,52 @@
     rgba(255, 255, 255, 0.06),
     transparent
   );
+}
+
+/* Desk surface the monitor sits on: a back-edge catch of streetlight and a
+   plane that brightens just past the edge, then falls away toward the room. */
+.tk-desk {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 22%;
+  pointer-events: none;
+}
+
+.tk-desk::before {
+  content: "";
+  position: absolute;
+  top: -1px;
+  right: 0;
+  left: 0;
+  height: 2px;
+  background: linear-gradient(
+    90deg,
+    transparent 6%,
+    rgba(255, 190, 120, 0.06) 40%,
+    rgba(255, 200, 130, 0.14) 76%,
+    rgba(255, 200, 130, 0.04) 98%
+  );
+}
+
+.tk-desk::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(
+      130% 90% at 86% 0%,
+      rgba(255, 165, 85, 0.055) 0%,
+      rgba(255, 150, 70, 0.02) 35%,
+      transparent 60%
+    ),
+    linear-gradient(
+      180deg,
+      rgba(40, 30, 21, 0.45) 0%,
+      rgba(18, 13, 9, 0.25) 30%,
+      rgba(0, 0, 0, 0.55) 100%
+    );
 }
 
 /* The tube is the brightest thing in the room: phosphor halo on the wall
@@ -1008,26 +1071,49 @@
   }
 }
 
-.tk-underglow {
-  position: relative;
-  z-index: 0;
-  height: 0;
+/* Seats the monitor on the desk: a tight contact shadow at the base and the
+   screen's reflection pooling on the surface in front. Attached to the
+   monitor so it stays aligned at any viewport size. */
+.tk-monitor-seat {
+  position: absolute;
+  top: 100%;
+  right: -4%;
+  left: -4%;
+  height: 110px;
+  pointer-events: none;
 }
 
-.tk-underglow::after {
-  content: "";
+.tk-monitor-seat-shadow {
   position: absolute;
-  right: 8%;
-  bottom: -14px;
-  left: 8%;
-  height: 32px;
-  pointer-events: none;
+  top: 0;
+  right: 3%;
+  left: 3%;
+  height: 58px;
   background: radial-gradient(
-    ellipse at center,
-    rgba(57, 255, 90, 0.22) 0%,
-    transparent 70%
+    ellipse 56% 64% at 50% 0%,
+    rgba(0, 0, 0, 0.85) 0%,
+    rgba(0, 0, 0, 0.4) 45%,
+    transparent 74%
   );
-  filter: blur(8px);
+  filter: blur(7px);
+}
+
+.tk-monitor-seat-glow {
+  position: absolute;
+  top: 4px;
+  right: 9%;
+  left: 9%;
+  height: 128px;
+  background: radial-gradient(
+    ellipse 52% 58% at 50% 6%,
+    rgba(57, 255, 90, 0.24) 0%,
+    rgba(57, 255, 90, 0.07) 55%,
+    transparent 78%
+  );
+  filter: blur(9px);
+  mix-blend-mode: screen;
+  opacity: 0.65;
+  animation: tk-breathe 6s ease-in-out infinite;
 }
 
 .tk-apron {

--- a/virtualis-terminal/components/RoomScene/RoomScene.tsx
+++ b/virtualis-terminal/components/RoomScene/RoomScene.tsx
@@ -115,16 +115,19 @@ export function RoomScene({ children }: RoomSceneProps) {
       <div className="tk-room" aria-hidden="true">
         <div className="tk-rim" />
         <div className="tk-streetlight" />
-        <div className="tk-blinds-perspective">
-          <div className="tk-blinds" />
-          {carEvent ? (
-            <div
-              key={carEvent.id}
-              className={`tk-blinds-carlight tk-blinds-carlight-${carEvent.dir}`}
-            />
-          ) : null}
+        <div className="tk-window-light">
+          <div className="tk-blinds-perspective">
+            <div className="tk-blinds" />
+            {carEvent ? (
+              <div
+                key={carEvent.id}
+                className={`tk-blinds-carlight tk-blinds-carlight-${carEvent.dir}`}
+              />
+            ) : null}
+          </div>
         </div>
         <div className="tk-floor" />
+        <div className="tk-desk" />
         {carEvent ? (
           <div
             key={carEvent.id}
@@ -196,7 +199,10 @@ export function RoomScene({ children }: RoomSceneProps) {
           <Vent />
         </div>
 
-        <div className="tk-underglow" aria-hidden="true" />
+        <div className="tk-monitor-seat" aria-hidden="true">
+          <div className="tk-monitor-seat-shadow" />
+          <div className="tk-monitor-seat-glow" />
+        </div>
 
         <div className="tk-apron">
           <div className="tk-brand">


### PR DESCRIPTION
Dependent on #14 (base branch). Gives the monitor a surface to sit on — and makes it read as a *plane*, not wainscoting.

## Why the first attempt read flat

The blind shadows painted one uninterrupted pattern across the wall-desk boundary. Same pattern + same angle + same spacing = same surface; no tonal band can argue with that. The stripes *are* the plane.

## The fix: terminate the light, don't bend it

Rather than re-projecting the slat pattern onto a foreshortened desk plane (a junction-continuity problem CSS gradients can't win — a near-miss fold reads worse than none), the window light simply stops at the desk edge:

- A new untransformed `tk-window-light` wrapper around the blinds projection carries one mask that cuts the static slats **and** the sweeping car-pass bars together at the fold, with a short grazing fade just past the edge. It sits outside the `matrix3d`, so the cut is exactly horizontal — a mask inside the transform tilts ~58px across the frame (measured before moving it).
- Physical story: the window has a sill and the shaft descends from a high streetlight; the desk lives in the sill's shadow. Perceptual story: **pattern termination is itself the depth cue** — stripes ending abruptly say "the surface they were painted on ends here."
- The unstriped car-pass glow still floods the desk softly during a pass (bounce light), so the desk participates in events without inheriting the wall's pattern.

## The desk itself

- `tk-desk`: bottom 22% plane — back-edge highlight catching the streetlight (strongest toward the window), dim warm sheen falling away, darkening toward the viewer. Deliberately darker than the wall: equal illumination implies equal orientation.
- `tk-monitor-seat` (replaces the invisible `tk-underglow`): contact shadow at the monitor's base plus the screen's phosphor reflection pooling on the surface in front, breathing on the existing `tk-breathe` cycle. Attached to the monitor element so it stays aligned at any viewport size.

## Verification

Full-res crops at rest and mid-pass: slats terminate at the fold in both states; during a pass the bright bars rake the wall and stop dead at the edge while the desk catches only the soft flood. Mask presence verified via computed style; tilt corrected by the wrapper move. `format` / `lint` / `tsc` / `test:unit` (32) / `test:e2e` (11/11) / `build` all green.

https://claude.ai/code/session_01KfCfdeCQw8yWZgvzof9o6R

---
_Generated by [Claude Code](https://claude.ai/code/session_01KfCfdeCQw8yWZgvzof9o6R)_